### PR TITLE
Update sync_vm Dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/geometry_config_generator/main.rs"
 
 zkevm-assembly = {git = "https://github.com/matter-labs/era-zkEVM-assembly.git", branch = "v1.3.2"}
 zk_evm = {git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc0"}
-sync_vm = {git = "https://github.com/matter-labs/era-sync_vm.git", branch = "v1.3.3", features = ["external_testing"]}
+sync_vm = {git = "https://github.com/matter-labs/era-sync_vm.git", tag = "v1.3.3-rc0", features = ["external_testing"]}
 circuit_testing = {git = "https://github.com/matter-labs/era-circuit_testing.git", branch = "main"}
 
 num-bigint = "0.4"


### PR DESCRIPTION
### What

This PR modifies the sync_vm dependency from branch v1.3.3 to the v1.3.3-rc0 tag.