### PR TITLE
Mirrors branch v1.3.3 from private at 5e43c2f196302df153f045be4f6902f2502427fb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ node_proof_*.*
 .DS_Store
 scheduler_*.*
 node_output_*.*
-

--- a/src/geometry_config/mod.rs
+++ b/src/geometry_config/mod.rs
@@ -4,7 +4,7 @@ use crate::toolset::GeometryConfig;
 
 pub const fn get_geometry_config() -> GeometryConfig {
     GeometryConfig {
-    cycles_per_vm_snapshot: 22893,
+    cycles_per_vm_snapshot: 22870,
     cycles_per_code_decommitter_sorter: 192832,
     cycles_per_log_demuxer: 101830,
     cycles_per_storage_sorter: 79603,


### PR DESCRIPTION
This PR fails due to `fmt` the code. Leaving it as is to have one commit that mirrored the private repo perfectly.