### PR TITLE
Fix witness generation logic, update circuits with missing gates

### DIFF
--- a/circuit_definitions/Cargo.toml
+++ b/circuit_definitions/Cargo.toml
@@ -24,6 +24,7 @@ zk_evm = {git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.
 derivative = "*"
 serde = {version = "1", features = ["derive"]}
 crossbeam = "0.8"
+seq-macro = "0.3.5"
 
 [features]
 default = []

--- a/circuit_definitions/src/circuit_definitions/base_layer/ecrecover.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/ecrecover.rs
@@ -15,8 +15,11 @@ pub struct ECRecoverFunctionInstanceSynthesisFunction<
     _marker: std::marker::PhantomData<(F, R)>,
 }
 
-use zkevm_circuits::ecrecover::ecrecover_function_entry_point;
 use zkevm_circuits::ecrecover::input::*;
+use zkevm_circuits::ecrecover::{
+    decomp_table::*, ecrecover_function_entry_point, naf_abs_div2_table::*,
+    secp256k1::fixed_base_mul_table::*,
+};
 
 impl<
         F: SmallField,
@@ -69,7 +72,10 @@ where
                 share_constants: false,
             },
         );
-
+        let builder = U8x4FMAGate::configure_builder(
+            builder,
+            GatePlacementStrategy::UseGeneralPurposeColumns,
+        );
         let builder = ZeroCheckGate::configure_builder(
             builder,
             GatePlacementStrategy::UseGeneralPurposeColumns,
@@ -84,6 +90,10 @@ where
             GatePlacementStrategy::UseGeneralPurposeColumns,
         );
         let builder = UIntXAddGate::<16>::configure_builder(
+            builder,
+            GatePlacementStrategy::UseGeneralPurposeColumns,
+        );
+        let builder = UIntXAddGate::<8>::configure_builder(
             builder,
             GatePlacementStrategy::UseGeneralPurposeColumns,
         );
@@ -146,6 +156,31 @@ where
 
         let table = create_and8_table();
         cs.add_lookup_table::<And8Table, 3>(table);
+
+        let table = create_naf_abs_div2_table();
+        cs.add_lookup_table::<NafAbsDiv2Table, 3>(table);
+
+        let table = create_wnaf_decomp_table();
+        cs.add_lookup_table::<WnafDecompTable, 3>(table);
+
+        seq_macro::seq!(C in 0..32 {
+            let table = create_fixed_base_mul_table::<F, 0, C>();
+            cs.add_lookup_table::<FixedBaseMulTable<0, C>, 3>(table);
+            let table = create_fixed_base_mul_table::<F, 1, C>();
+            cs.add_lookup_table::<FixedBaseMulTable<1, C>, 3>(table);
+            let table = create_fixed_base_mul_table::<F, 2, C>();
+            cs.add_lookup_table::<FixedBaseMulTable<2, C>, 3>(table);
+            let table = create_fixed_base_mul_table::<F, 3, C>();
+            cs.add_lookup_table::<FixedBaseMulTable<3, C>, 3>(table);
+            let table = create_fixed_base_mul_table::<F, 4, C>();
+            cs.add_lookup_table::<FixedBaseMulTable<4, C>, 3>(table);
+            let table = create_fixed_base_mul_table::<F, 5, C>();
+            cs.add_lookup_table::<FixedBaseMulTable<5, C>, 3>(table);
+            let table = create_fixed_base_mul_table::<F, 6, C>();
+            cs.add_lookup_table::<FixedBaseMulTable<6, C>, 3>(table);
+            let table = create_fixed_base_mul_table::<F, 7, C>();
+            cs.add_lookup_table::<FixedBaseMulTable<7, C>, 3>(table);
+        });
 
         let table = create_byte_split_table::<F, 1>();
         cs.add_lookup_table::<ByteSplitTable<1>, 3>(table);

--- a/circuit_definitions/src/circuit_definitions/base_layer/keccak256_round_function.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/keccak256_round_function.rs
@@ -87,6 +87,10 @@ where
             builder,
             GatePlacementStrategy::UseGeneralPurposeColumns,
         );
+        let builder = UIntXAddGate::<8>::configure_builder(
+            builder,
+            GatePlacementStrategy::UseGeneralPurposeColumns,
+        );
         let builder = SelectionGate::configure_builder(
             builder,
             GatePlacementStrategy::UseGeneralPurposeColumns,

--- a/src/external_calls.rs
+++ b/src/external_calls.rs
@@ -229,7 +229,7 @@ round_function: R, // used for all queues implementation
     // dbg!(tools.witness_tracer.vm_snapshots.len());
 
     let (instance_oracles, artifacts) = create_artifacts_from_tracer(
-        out_of_circuit_vm.witness_tracer,
+        &mut out_of_circuit_vm.witness_tracer,
         &round_function,
         &geometry,
         (

--- a/src/witness/individual_circuits/events_sort_dedup.rs
+++ b/src/witness/individual_circuits/events_sort_dedup.rs
@@ -32,7 +32,7 @@ pub fn compute_events_dedup_and_sort<
         // return singe dummy witness
         use crate::boojum::gadgets::queue::QueueState;
 
-        let initial_fsm_state = EventsDeduplicatorFSMInputOutput::<F>::placeholder_witness();
+        let mut initial_fsm_state = EventsDeduplicatorFSMInputOutput::<F>::placeholder_witness();
 
         assert_eq!(
             take_queue_state_from_simulator(&unsorted_simulator),
@@ -44,7 +44,13 @@ pub fn compute_events_dedup_and_sort<
             take_queue_state_from_simulator(&unsorted_simulator);
         passthrough_input.intermediate_sorted_queue_state = QueueState::placeholder_witness();
 
-        let final_fsm_state = EventsDeduplicatorFSMInputOutput::<F>::placeholder_witness();
+        let mut final_fsm_state = EventsDeduplicatorFSMInputOutput::<F>::placeholder_witness();
+        // NOTE: little hack to make the trivial case work. we should really however remove the
+        // requirement to have trivial events sorter circuits in the scheduler.
+        initial_fsm_state.lhs_accumulator = [F::ONE; 2];
+        initial_fsm_state.rhs_accumulator = [F::ONE; 2];
+        final_fsm_state.lhs_accumulator = [F::ONE; 2];
+        final_fsm_state.rhs_accumulator = [F::ONE; 2];
 
         let mut passthrough_output = EventsDeduplicatorOutputData::placeholder_witness();
         passthrough_output.final_queue_state = QueueState::placeholder_witness();

--- a/src/witness/individual_circuits/storage_application.rs
+++ b/src/witness/individual_circuits/storage_application.rs
@@ -4,7 +4,9 @@ use crate::boojum::sha3::digest::{FixedOutput, Update};
 use crate::boojum::sha3::Keccak256;
 use crate::witness::individual_circuits::keccak256_round_function::encode_kecca256_inner_state;
 use crate::witness::tree::*;
-use crate::zk_evm::zk_evm_abstractions::precompiles::keccak256::{transmute_state, BUFFER_SIZE};
+use crate::zk_evm::zk_evm_abstractions::precompiles::keccak256::{
+    transmute_state, KECCAK_PRECOMPILE_BUFFER_SIZE,
+};
 use crate::zkevm_circuits::base_structures::state_diff_record::NUM_KECCAK256_ROUNDS_PER_RECORD_ACCUMULATION;
 use crate::zkevm_circuits::storage_application::input::*;
 use blake2::Blake2s256;

--- a/src/witness/oracle.rs
+++ b/src/witness/oracle.rs
@@ -173,7 +173,7 @@ pub fn create_artifacts_from_tracer<
     F: SmallField,
     R: BuildableCircuitRoundFunction<F, 8, 12, 4> + AlgebraicRoundFunction<F, 8, 12, 4>,
 >(
-    tracer: WitnessTracer,
+    tracer: &mut WitnessTracer,
     round_function: &R,
     geometry: &GeometryConfig,
     entry_point_decommittment_query: (DecommittmentQuery, Vec<U256>),
@@ -933,11 +933,11 @@ pub fn create_artifacts_from_tracer<
     // when it potentially came into and out of scope
 
     let mut artifacts = FullBlockArtifacts::<F>::default();
-    artifacts.vm_memory_queries_accumulated = vm_memory_queries_accumulated;
-    artifacts.all_decommittment_queries = decommittment_queries;
-    artifacts.keccak_round_function_witnesses = keccak_round_function_witnesses;
-    artifacts.sha256_round_function_witnesses = sha256_round_function_witnesses;
-    artifacts.ecrecover_witnesses = ecrecover_witnesses;
+    artifacts.vm_memory_queries_accumulated = vm_memory_queries_accumulated.to_vec();
+    artifacts.all_decommittment_queries = decommittment_queries.to_vec();
+    artifacts.keccak_round_function_witnesses = keccak_round_function_witnesses.to_vec();
+    artifacts.sha256_round_function_witnesses = sha256_round_function_witnesses.to_vec();
+    artifacts.ecrecover_witnesses = ecrecover_witnesses.to_vec();
     artifacts.original_log_queue = original_log_queue;
     artifacts.original_log_queue_simulator =
         original_log_queue_simulator.unwrap_or(LogQueueSimulator::empty());


### PR DESCRIPTION
# What ❔

This PR fixes witness generation logic for the keccak and events sorter circuits, updates the logic to use the owned `VmState` object and catches up with circuit updates by adding missing gates.

## Why ❔

Trying to be compatible with other repos at v1.4.1.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
