### PR TITLE
Fix test breakage from latest updates, update main circuit for new memory cost formula

### DIFF
--- a/circuit_definitions/src/circuit_definitions/base_layer/vm_main.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/vm_main.rs
@@ -184,6 +184,12 @@ where
 
         let uma_ptr_read_cleanup_table = create_uma_ptr_read_bitmask_table::<F>();
         cs.add_lookup_table::<UMAPtrReadCleanupTable, 3>(uma_ptr_read_cleanup_table);
+
+        let split_table_1 = create_byte_split_table::<F, 1>();
+        cs.add_lookup_table::<ByteSplitTable<1>, 3>(split_table_1);
+
+        let split_table_7 = create_byte_split_table::<F, 7>();
+        cs.add_lookup_table::<ByteSplitTable<7>, 3>(split_table_7);
     }
 
     fn synthesize_into_cs_inner<CS: ConstraintSystem<F>>(

--- a/src/tests/simple_tests/memory_growth.rs
+++ b/src/tests/simple_tests/memory_growth.rs
@@ -65,7 +65,7 @@ fn test_ret_memory_growth_out_of_ergs() {
         event.first r0, r0
         to_l1.first r0, r0
         add 1, r0, r1
-        shl.s 32, r1, r1
+        shl.s 30, r1, r1
         sub.s 1, r1, r1
         shl.s 96, r1, r1
         ret r1

--- a/src/witness/individual_circuits/keccak256_round_function.rs
+++ b/src/witness/individual_circuits/keccak256_round_function.rs
@@ -320,8 +320,9 @@ pub fn keccak256_decompose_into_per_circuit_witness<
                     zk_evm::zk_evm_abstractions::precompiles::keccak256::transmute_state(
                         internal_state.clone(),
                     );
-                let mut u64_words_buffer_markers =
-                    [false; zkevm_circuits::keccak256_round_function::BUFFER_SIZE_IN_U64_WORDS];
+                let mut u64_words_buffer_markers = [false;
+                    zkevm_circuits::keccak256_round_function::input::KECCAK_PRECOMPILE_BUFFER_SIZE
+                        / 8];
                 for i in 0..input_buffer.filled {
                     u64_words_buffer_markers[i] = true;
                 }


### PR DESCRIPTION
# What ❔

Fixes test breakage observed from latest updates, and updates the main VM circuit tables to include byte splitters needed for calculating the new memory growth cost function.

## Why ❔

This keeps the test harness intact for further testing of changes made for v1.4.1. 

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
