### PR TITLE
perf: Reduce memory consumption without changing the interface

### DIFF
--- a/src/witness/individual_circuits/ecrecover.rs
+++ b/src/witness/individual_circuits/ecrecover.rs
@@ -86,7 +86,7 @@ pub fn ecrecover_decompose_into_per_circuit_witness<
                 },
                 hidden_fsm_output: EcrecoverCircuitFSMInputOutputWitness::<F> {
                     log_queue_state: take_queue_state_from_simulator(
-                        &artifacts.demuxed_sha256_precompile_queue_simulator,
+                        &artifacts.demuxed_ecrecover_queue_simulator,
                     ),
                     memory_queue_state: current_memory_queue_state.clone(),
                 },

--- a/src/witness/individual_circuits/ecrecover.rs
+++ b/src/witness/individual_circuits/ecrecover.rs
@@ -53,7 +53,7 @@ pub fn ecrecover_decompose_into_per_circuit_witness<
     let simulator_witness: Vec<_> = demuxed_ecrecover_queue.simulator.witness.clone().into();
     let round_function_witness = std::mem::replace(&mut artifacts.ecrecover_witnesses, vec![]);
 
-    let memory_queries = std::mem::replace(&mut ecrecover_memory_queries, vec![]);
+    let memory_queries = ecrecover_memory_queries;
 
     // check basic consistency
     assert!(precompile_calls.len() == precompile_calls_queue_states.len());

--- a/src/witness/individual_circuits/ecrecover.rs
+++ b/src/witness/individual_circuits/ecrecover.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::witness::full_block_artifact::LogQueue;
 use crate::zk_evm::zkevm_opcode_defs::ethereum_types::U256;
 use crate::zkevm_circuits::base_structures::log_query::*;
 use crate::zkevm_circuits::ecrecover::*;
@@ -13,6 +14,7 @@ pub fn ecrecover_decompose_into_per_circuit_witness<
     R: BuildableCircuitRoundFunction<F, 8, 12, 4> + AlgebraicRoundFunction<F, 8, 12, 4>,
 >(
     artifacts: &mut FullBlockArtifacts<F>,
+    mut demuxed_ecrecover_queue: LogQueue<F>,
     num_rounds_per_circuit: usize,
     round_function: &R,
 ) -> Vec<EcrecoverCircuitInstanceWitness<F>> {
@@ -28,6 +30,8 @@ pub fn ecrecover_decompose_into_per_circuit_witness<
     // split into aux witness, don't mix with the memory
 
     use crate::zk_evm::zk_evm_abstractions::precompiles::ecrecover::ECRecoverRoundWitness;
+    let mut ecrecover_memory_queries = vec![];
+
     for (_cycle, _query, witness) in artifacts.ecrecover_witnesses.iter() {
         let ECRecoverRoundWitness {
             new_request: _,
@@ -36,24 +40,20 @@ pub fn ecrecover_decompose_into_per_circuit_witness<
         } = witness;
 
         // we read, then write
-        artifacts.ecrecover_memory_queries.extend_from_slice(reads);
+        ecrecover_memory_queries.extend_from_slice(reads);
 
-        artifacts.ecrecover_memory_queries.extend_from_slice(writes);
+        ecrecover_memory_queries.extend_from_slice(writes);
     }
 
     let mut result = vec![];
 
     let precompile_calls = std::mem::replace(&mut artifacts.demuxed_ecrecover_queries, vec![]);
     let precompile_calls_queue_states =
-        std::mem::replace(&mut artifacts.demuxed_ecrecover_queue_states, vec![]);
-    let simulator_witness: Vec<_> = artifacts
-        .demuxed_ecrecover_queue_simulator
-        .witness
-        .clone()
-        .into();
+        std::mem::replace(&mut demuxed_ecrecover_queue.states, vec![]);
+    let simulator_witness: Vec<_> = demuxed_ecrecover_queue.simulator.witness.clone().into();
     let round_function_witness = std::mem::replace(&mut artifacts.ecrecover_witnesses, vec![]);
 
-    let memory_queries = std::mem::replace(&mut artifacts.ecrecover_memory_queries, vec![]);
+    let memory_queries = std::mem::replace(&mut ecrecover_memory_queries, vec![]);
 
     // check basic consistency
     assert!(precompile_calls.len() == precompile_calls_queue_states.len());
@@ -62,7 +62,7 @@ pub fn ecrecover_decompose_into_per_circuit_witness<
     if precompile_calls.len() == 0 {
         // we can not skip the circuit (at least for now), so we have to create a dummy on
         let log_queue_input_state =
-            take_queue_state_from_simulator(&artifacts.demuxed_ecrecover_queue_simulator);
+            take_queue_state_from_simulator(&demuxed_ecrecover_queue.simulator);
         let memory_queue_input_state =
             take_sponge_like_queue_state_from_simulator(&artifacts.memory_queue_simulator);
         let current_memory_queue_state = memory_queue_input_state.clone();
@@ -86,7 +86,7 @@ pub fn ecrecover_decompose_into_per_circuit_witness<
                 },
                 hidden_fsm_output: EcrecoverCircuitFSMInputOutputWitness::<F> {
                     log_queue_state: take_queue_state_from_simulator(
-                        &artifacts.demuxed_ecrecover_queue_simulator,
+                        &demuxed_ecrecover_queue.simulator,
                     ),
                     memory_queue_state: current_memory_queue_state.clone(),
                 },
@@ -111,7 +111,7 @@ pub fn ecrecover_decompose_into_per_circuit_witness<
 
     // convension
     let mut log_queue_input_state =
-        take_queue_state_from_simulator(&artifacts.demuxed_ecrecover_queue_simulator);
+        take_queue_state_from_simulator(&demuxed_ecrecover_queue.simulator);
     let mut memory_queries_it = memory_queries.into_iter();
 
     let mut memory_read_witnesses = vec![];
@@ -129,8 +129,8 @@ pub fn ecrecover_decompose_into_per_circuit_witness<
         .zip(round_function_witness.into_iter())
         .enumerate()
     {
-        let _ = artifacts
-            .demuxed_ecrecover_queue_simulator
+        let _ = demuxed_ecrecover_queue
+            .simulator
             .pop_and_output_intermediate_data(round_function);
         let initial_memory_len = artifacts.memory_queue_simulator.num_items;
 
@@ -225,7 +225,7 @@ pub fn ecrecover_decompose_into_per_circuit_witness<
                     },
                     hidden_fsm_output: EcrecoverCircuitFSMInputOutputWitness::<F> {
                         log_queue_state: take_queue_state_from_simulator(
-                            &artifacts.demuxed_ecrecover_queue_simulator,
+                            &demuxed_ecrecover_queue.simulator,
                         ),
                         memory_queue_state: current_memory_queue_state.clone(),
                     },
@@ -253,7 +253,7 @@ pub fn ecrecover_decompose_into_per_circuit_witness<
             result.push(witness);
 
             log_queue_input_state =
-                take_queue_state_from_simulator(&artifacts.demuxed_ecrecover_queue_simulator);
+                take_queue_state_from_simulator(&demuxed_ecrecover_queue.simulator);
             memory_queue_input_state = current_memory_queue_state.clone();
         }
 

--- a/src/witness/individual_circuits/keccak256_round_function.rs
+++ b/src/witness/individual_circuits/keccak256_round_function.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::witness::full_block_artifact::LogQueue;
 use crate::zkevm_circuits::base_structures::log_query::*;
 use crate::zkevm_circuits::keccak256_round_function::{
     input::*, Keccak256PrecompileCallParamsWitness,
@@ -23,6 +24,7 @@ pub fn keccak256_decompose_into_per_circuit_witness<
     R: BuildableCircuitRoundFunction<F, 8, 12, 4> + AlgebraicRoundFunction<F, 8, 12, 4>,
 >(
     artifacts: &mut FullBlockArtifacts<F>,
+    mut demuxed_keccak_precompile_queue: LogQueue<F>,
     num_rounds_per_circuit: usize,
     round_function: &R,
 ) -> Vec<Keccak256RoundFunctionCircuitInstanceWitness<F>> {
@@ -38,6 +40,8 @@ pub fn keccak256_decompose_into_per_circuit_witness<
     // split into aux witness, don't mix with the memory
     use crate::zk_evm::zk_evm_abstractions::precompiles::keccak256::Keccak256RoundWitness;
 
+    let mut keccak_256_memory_queries = vec![];
+
     for (_cycle, _query, witness) in artifacts.keccak_round_function_witnesses.iter() {
         for el in witness.iter() {
             let Keccak256RoundWitness {
@@ -48,13 +52,11 @@ pub fn keccak256_decompose_into_per_circuit_witness<
 
             // we read, then write
             if let Some(reads) = reads.as_ref() {
-                artifacts.keccak_256_memory_queries.extend_from_slice(reads);
+                keccak_256_memory_queries.extend_from_slice(reads);
             }
 
             if let Some(writes) = writes.as_ref() {
-                artifacts
-                    .keccak_256_memory_queries
-                    .extend_from_slice(writes);
+                keccak_256_memory_queries.extend_from_slice(writes);
             }
         }
     }
@@ -63,19 +65,17 @@ pub fn keccak256_decompose_into_per_circuit_witness<
 
     let keccak_precompile_calls =
         std::mem::replace(&mut artifacts.demuxed_keccak_precompile_queries, vec![]);
-    let keccak_precompile_calls_queue_states = std::mem::replace(
-        &mut artifacts.demuxed_keccak_precompile_queue_states,
-        vec![],
-    );
-    let simulator_witness: Vec<_> = artifacts
-        .demuxed_keccak_precompile_queue_simulator
+    let keccak_precompile_calls_queue_states =
+        std::mem::replace(&mut demuxed_keccak_precompile_queue.states, vec![]);
+    let simulator_witness: Vec<_> = demuxed_keccak_precompile_queue
+        .simulator
         .witness
         .clone()
         .into();
     let round_function_witness =
         std::mem::replace(&mut artifacts.keccak_round_function_witnesses, vec![]);
 
-    let memory_queries = std::mem::replace(&mut artifacts.keccak_256_memory_queries, vec![]);
+    let memory_queries = std::mem::replace(&mut keccak_256_memory_queries, vec![]);
 
     // check basic consistency
     assert_eq!(
@@ -87,7 +87,7 @@ pub fn keccak256_decompose_into_per_circuit_witness<
     if keccak_precompile_calls.len() == 0 {
         // we can not skip the circuit (at least for now), so we have to create a dummy on
         let log_queue_input_state =
-            take_queue_state_from_simulator(&artifacts.demuxed_keccak_precompile_queue_simulator);
+            take_queue_state_from_simulator(&demuxed_keccak_precompile_queue.simulator);
         let memory_queue_input_state =
             take_sponge_like_queue_state_from_simulator(&artifacts.memory_queue_simulator);
         let current_memory_queue_state = memory_queue_input_state.clone();
@@ -134,7 +134,7 @@ pub fn keccak256_decompose_into_per_circuit_witness<
                 hidden_fsm_output: Keccak256RoundFunctionFSMInputOutputWitness::<F> {
                     internal_fsm: hidden_fsm_output_state,
                     log_queue_state: take_queue_state_from_simulator(
-                        &artifacts.demuxed_keccak_precompile_queue_simulator,
+                        &demuxed_keccak_precompile_queue.simulator,
                     ),
                     memory_queue_state: current_memory_queue_state.clone(),
                 },
@@ -159,7 +159,7 @@ pub fn keccak256_decompose_into_per_circuit_witness<
 
     // convension
     let mut log_queue_input_state =
-        take_queue_state_from_simulator(&artifacts.demuxed_keccak_precompile_queue_simulator);
+        take_queue_state_from_simulator(&demuxed_keccak_precompile_queue.simulator);
 
     let mut hidden_fsm_input_state = Keccak256RoundFunctionFSM::<F>::placeholder_witness();
     hidden_fsm_input_state.read_precompile_call = true;
@@ -186,8 +186,8 @@ pub fn keccak256_decompose_into_per_circuit_witness<
     {
         // request level. Each request can be broken into few rounds
 
-        let _ = artifacts
-            .demuxed_keccak_precompile_queue_simulator
+        let _ = demuxed_keccak_precompile_queue
+            .simulator
             .pop_and_output_intermediate_data(round_function);
 
         use crate::zk_evm::zk_evm_abstractions::precompiles::keccak256::Keccak256;
@@ -413,7 +413,7 @@ pub fn keccak256_decompose_into_per_circuit_witness<
                         hidden_fsm_output: Keccak256RoundFunctionFSMInputOutputWitness::<F> {
                             internal_fsm: hidden_fsm_output_state.clone(),
                             log_queue_state: take_queue_state_from_simulator(
-                                &artifacts.demuxed_keccak_precompile_queue_simulator,
+                                &demuxed_keccak_precompile_queue.simulator,
                             ),
                             memory_queue_state: current_memory_queue_state.clone(),
                         },
@@ -435,9 +435,8 @@ pub fn keccak256_decompose_into_per_circuit_witness<
 
                 result.push(witness);
 
-                log_queue_input_state = take_queue_state_from_simulator(
-                    &artifacts.demuxed_keccak_precompile_queue_simulator,
-                );
+                log_queue_input_state =
+                    take_queue_state_from_simulator(&demuxed_keccak_precompile_queue.simulator);
                 hidden_fsm_input_state = hidden_fsm_output_state;
                 memory_queue_input_state = current_memory_queue_state.clone();
             }

--- a/src/witness/individual_circuits/keccak256_round_function.rs
+++ b/src/witness/individual_circuits/keccak256_round_function.rs
@@ -75,7 +75,7 @@ pub fn keccak256_decompose_into_per_circuit_witness<
     let round_function_witness =
         std::mem::replace(&mut artifacts.keccak_round_function_witnesses, vec![]);
 
-    let memory_queries = std::mem::replace(&mut keccak_256_memory_queries, vec![]);
+    let memory_queries = keccak_256_memory_queries;
 
     // check basic consistency
     assert_eq!(

--- a/src/witness/individual_circuits/sha256_round_function.rs
+++ b/src/witness/individual_circuits/sha256_round_function.rs
@@ -73,7 +73,7 @@ pub fn sha256_decompose_into_per_circuit_witness<
     let round_function_witness =
         std::mem::replace(&mut artifacts.sha256_round_function_witnesses, vec![]);
 
-    let memory_queries = std::mem::replace(&mut sha256_memory_queries, vec![]);
+    let memory_queries = sha256_memory_queries;
 
     // check basic consistency
     assert!(precompile_calls.len() == precompile_calls_queue_states.len());

--- a/src/witness/oracle.rs
+++ b/src/witness/oracle.rs
@@ -263,17 +263,6 @@ pub fn create_artifacts_from_tracer<
     let mut demuxed_keccak_precompile_queries = vec![];
     let mut demuxed_sha256_precompile_queries = vec![];
     let mut demuxed_ecrecover_queries = vec![];
-    let original_log_queue: Vec<_> = forward
-        .iter()
-        .filter(|el| match el {
-            ExtendedLogQuery::Query { .. } => true,
-            _ => false,
-        })
-        .map(|el| match el {
-            ExtendedLogQuery::Query { cycle, query, .. } => (*cycle, *query),
-            _ => unreachable!(),
-        })
-        .collect();
 
     let mut original_log_queue_states = vec![];
     let mut chain_of_states = vec![];
@@ -938,13 +927,11 @@ pub fn create_artifacts_from_tracer<
     artifacts.keccak_round_function_witnesses = keccak_round_function_witnesses;
     artifacts.sha256_round_function_witnesses = sha256_round_function_witnesses;
     artifacts.ecrecover_witnesses = ecrecover_witnesses;
-    artifacts.original_log_queue = original_log_queue;
     artifacts.original_log_queue_simulator =
         original_log_queue_simulator.unwrap_or(LogQueueSimulator::empty());
     artifacts.original_log_queue_states = original_log_queue_states;
 
     artifacts.demuxed_rollup_storage_queries = demuxed_rollup_storage_queries;
-    artifacts.demuxed_porter_storage_queries = demuxed_porter_storage_queries;
     artifacts.demuxed_event_queries = demuxed_event_queries;
     artifacts.demuxed_to_l1_queries = demuxed_to_l1_queries;
     artifacts.demuxed_keccak_precompile_queries = demuxed_keccak_precompile_queries;


### PR DESCRIPTION
# What ❔

Remove unused fields, variables. Move FullBlockArtifacts' fields that are used for temporaries into local variables.

Also fixed a trivial bug (confirmed to be a bug by @shamatar).

## Why ❔

This reduces memory consumption by about 10% and memory consumption is a big problem for us.