### PR TITLE
Use era-zkevm_circuits repo

### DIFF
--- a/circuit_definitions/Cargo.toml
+++ b/circuit_definitions/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 snark_wrapper = {git = "https://github.com/matter-labs/snark-wrapper.git", branch = "main"}
 # snark_wrapper = {path = "../../snark_wrapper"}
 
-zkevm_circuits = {git = "https://github.com/matter-labs/zkevm_circuits.git", branch = "v1.4.1"}
+zkevm_circuits = {git = "https://github.com/matter-labs/era-zkevm_circuits.git", branch = "v1.4.1"}
 zk_evm = {git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.1"}
 
 derivative = "*"


### PR DESCRIPTION
# What ❔

Use public circuits repo

## Why ❔

It's needed for the integration

## Checklist

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
