### PR TITLE
The same interface as 1.3.3 for sorting storage access queries (1.4.1)

### DIFF
--- a/src/witness/sort_storage_access.rs
+++ b/src/witness/sort_storage_access.rs
@@ -17,11 +17,11 @@ pub struct StorageSlotHistoryKeeper<L: LogQueryLike> {
     pub did_read_at_depth_zero: bool,
 }
 
-pub fn sort_storage_access_queries<L: LogQueryLike>(
-    unsorted_storage_queries: &[L],
+pub fn sort_storage_access_queries<'a, L: LogQueryLike, I: IntoIterator<Item = &'a L>>(
+    unsorted_storage_queries: I,
 ) -> (Vec<LogQueryLikeWithExtendedEnumeration<L>>, Vec<L>) {
     let mut sorted_storage_queries_with_extra_timestamp: Vec<_> = unsorted_storage_queries
-        .iter()
+        .into_iter()
         .enumerate()
         .map(|(i, el)| LogQueryLikeWithExtendedEnumeration {
             raw_query: el.clone(),


### PR DESCRIPTION
# What ❔

Using the same interface for sorting storage access queries as 1.3.3 as it is more efficient

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
