### PR TITLE
chore: remove stray dbg! macro

### DIFF
--- a/src/witness/individual_circuits/ecrecover.rs
+++ b/src/witness/individual_circuits/ecrecover.rs
@@ -148,8 +148,6 @@ pub fn ecrecover_decompose_into_per_circuit_witness<
             assert!(read_query.rw_flag == false);
             memory_reads_per_request.push(read_query.value);
 
-            dbg!(read_query.value);
-
             artifacts.all_memory_queries_accumulated.push(read);
             let (_, intermediate_info) = artifacts
                 .memory_queue_simulator
@@ -166,8 +164,6 @@ pub fn ecrecover_decompose_into_per_circuit_witness<
             let write_query = memory_queries_it.next().unwrap();
             assert!(write == write_query);
             assert!(write_query.rw_flag == true);
-
-            dbg!(write_query.value);
 
             artifacts.all_memory_queries_accumulated.push(write);
             let (_, intermediate_info) = artifacts


### PR DESCRIPTION
Looks like some changes were merged a bit hastily. Spotted this when looking at witgen logs.