### PR TITLE
perf: make witness generation use ~3x less memory

### DIFF
--- a/src/external_calls.rs
+++ b/src/external_calls.rs
@@ -232,7 +232,7 @@ pub fn run<
     // dbg!(tools.witness_tracer.vm_snapshots.len());
 
     let (basic_circuits, compact_form_witnesses) = create_artifacts_from_tracer(
-        &mut out_of_circuit_vm.witness_tracer,
+        out_of_circuit_vm.witness_tracer,
         &round_function,
         &geometry,
         (

--- a/src/witness/full_block_artifact.rs
+++ b/src/witness/full_block_artifact.rs
@@ -76,8 +76,6 @@ pub struct FullBlockArtifacts<F: SmallField> {
     pub sha256_round_function_witnesses: Vec<(u32, LogQuery, Vec<Sha256RoundWitness>)>,
     pub ecrecover_witnesses: Vec<(u32, LogQuery, ECRecoverRoundWitness)>,
 
-    // processed RAM circuit information
-    pub ram_permutation_circuits_data: Vec<RamPermutationCircuitInstanceWitness<F>>,
     // processed code decommitter circuits, as well as sorting circuit
     pub code_decommitter_circuits_data: Vec<CodeDecommitterCircuitInstanceWitness<F>>,
     pub decommittments_deduplicator_circuits_data:

--- a/src/witness/full_block_artifact.rs
+++ b/src/witness/full_block_artifact.rs
@@ -43,9 +43,6 @@ use tracing;
 pub struct FullBlockArtifacts<F: SmallField> {
     pub is_processed: bool,
     pub memory_queue_simulator: MemoryQueueSimulator<F>,
-
-    // all the RAM (without accumulation into the queue)
-    pub vm_memory_queries_accumulated: Vec<(u32, MemoryQuery)>,
     //
     pub all_memory_queries_accumulated: Vec<MemoryQuery>,
     // all the RAM queue states

--- a/src/witness/oracle.rs
+++ b/src/witness/oracle.rs
@@ -196,7 +196,7 @@ pub fn create_artifacts_from_tracer<
         Vec<ClosedFormInputCompactFormWitness<GoldilocksField>>,
     ),
 >(
-    tracer: &mut WitnessTracer,
+    tracer: WitnessTracer,
     round_function: &Poseidon2Goldilocks,
     geometry: &GeometryConfig,
     entry_point_decommittment_query: (DecommittmentQuery, Vec<U256>),
@@ -964,10 +964,10 @@ pub fn create_artifacts_from_tracer<
 
     let artifacts = {
         let mut artifacts = FullBlockArtifacts::default();
-        artifacts.all_decommittment_queries = decommittment_queries.to_vec();
-        artifacts.keccak_round_function_witnesses = keccak_round_function_witnesses.to_vec();
-        artifacts.sha256_round_function_witnesses = sha256_round_function_witnesses.to_vec();
-        artifacts.ecrecover_witnesses = ecrecover_witnesses.to_vec();
+        artifacts.all_decommittment_queries = decommittment_queries;
+        artifacts.keccak_round_function_witnesses = keccak_round_function_witnesses;
+        artifacts.sha256_round_function_witnesses = sha256_round_function_witnesses;
+        artifacts.ecrecover_witnesses = ecrecover_witnesses;
         artifacts.original_log_queue_simulator =
             original_log_queue_simulator.unwrap_or(LogQueueSimulator::empty());
         artifacts.original_log_queue_states = original_log_queue_states;
@@ -988,13 +988,13 @@ pub fn create_artifacts_from_tracer<
         tracing::debug!("Running memory queue simulation");
 
         for (cycle, query) in vm_memory_queries_accumulated {
-            this.all_memory_queries_accumulated.push(*query);
+            this.all_memory_queries_accumulated.push(query.clone());
 
             let (_old_tail, intermediate_info) = this
                 .memory_queue_simulator
-                .push_and_output_intermediate_data(*query, round_function);
+                .push_and_output_intermediate_data(query, round_function);
 
-            vm_memory_queue_states.push((*cycle, false, intermediate_info));
+            vm_memory_queue_states.push((cycle, false, intermediate_info));
             this.all_memory_queue_states.push(intermediate_info);
         }
 

--- a/src/witness/oracle.rs
+++ b/src/witness/oracle.rs
@@ -964,7 +964,6 @@ pub fn create_artifacts_from_tracer<
 
     let artifacts = {
         let mut artifacts = FullBlockArtifacts::default();
-        artifacts.vm_memory_queries_accumulated = vm_memory_queries_accumulated.to_vec();
         artifacts.all_decommittment_queries = decommittment_queries.to_vec();
         artifacts.keccak_round_function_witnesses = keccak_round_function_witnesses.to_vec();
         artifacts.sha256_round_function_witnesses = sha256_round_function_witnesses.to_vec();
@@ -988,7 +987,7 @@ pub fn create_artifacts_from_tracer<
 
         tracing::debug!("Running memory queue simulation");
 
-        for (cycle, query) in this.vm_memory_queries_accumulated.iter() {
+        for (cycle, query) in vm_memory_queries_accumulated {
             this.all_memory_queries_accumulated.push(*query);
 
             let (_old_tail, intermediate_info) = this
@@ -1001,7 +1000,7 @@ pub fn create_artifacts_from_tracer<
 
         assert!(
             this.memory_queue_simulator.num_items as usize
-                == this.vm_memory_queries_accumulated.len()
+                == this.all_memory_queries_accumulated.len()
         );
 
         // ----------------------------


### PR DESCRIPTION
# What ❔

Build RAM circuits and MainVM circuits just in time.

Unfortunately the whole list of inputs to RAM circuits has to be kept for a long time. To get rid of the last unnecessary memory use, witgen would have to be restructured so that all circuits are made one VM snapshot at a time.

## Why ❔

These circuits make up the vast majority of memory use.