### PR TITLE
move settings from lazy static to struct

### DIFF
--- a/src/kzg/mod.rs
+++ b/src/kzg/mod.rs
@@ -19,7 +19,7 @@ struct TrustedSetup {
 
 #[derive(Clone, Debug)]
 pub struct KzgSettings {
-    pub roots_of_unity_brp: Box<[Fr; FIELD_ELEMENTS_PER_BLOB]>,
+    pub roots_of_unity_brp: Vec<Fr>,
     pub setup_g2_1: G2,
     pub lagrange_setup_brp: Vec<G1Affine>,
 }
@@ -36,7 +36,7 @@ impl KzgSettings {
                 0x564c0a11a0f704f4,
             ]))
             .unwrap();
-            let mut roots = [Fr::one(); FIELD_ELEMENTS_PER_BLOB];
+            let mut roots = vec![Fr::one(); FIELD_ELEMENTS_PER_BLOB];
             roots[1] = base_root;
             (2..4096).for_each(|i| {
                 let prev_root = roots[i - 1];
@@ -44,7 +44,7 @@ impl KzgSettings {
                 roots[i].mul_assign(&prev_root);
             });
 
-            Box::new(roots)
+            roots
         };
 
         let roots_of_unity_brp = {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,6 +5,7 @@ use crate::boojum::config::*;
 use crate::boojum::cs::implementations::setup::FinalizationHintsForProver;
 use crate::boojum::field::goldilocks::GoldilocksExt2;
 use crate::boojum::{algebraic_props::round_function, field::SmallField};
+use crate::kzg::KzgSettings;
 use crate::witness::tree::BinaryHasher;
 use crate::zk_evm::{address_to_u256, ethereum_types::*};
 use circuit_definitions::encodings::{BytesSerializable, QueueSimulator};
@@ -207,7 +208,10 @@ pub fn generate_eip4844_witness<F: SmallField>(
 
     use crate::kzg::compute_commitment;
     use circuit_definitions::boojum::pairing::CurveAffine;
-    let commitment = compute_commitment(&blob_fr);
+    let setup_json: &str = "src/kzg/trusted_setup.json";
+    let settings = KzgSettings::new(setup_json);
+
+    let commitment = compute_commitment(&settings, &blob_fr);
     let mut versioned_hash: [u8; 32] = Keccak256::digest(&commitment.into_compressed())
         .try_into()
         .expect("should be able to create an array from a keccak digest");


### PR DESCRIPTION
# What ❔

move the values in lazy static variables into a shared struct that's passed a parameter

this also covers changes made by https://github.com/matter-labs/era-zkevm_test_harness/pull/72

## Why ❔

the lazy static variables rely on the trusted setup file being in a specific location, this decouples the dependency.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
