### PR TITLE
perf: cut witgen memory spike

### DIFF
--- a/src/witness/full_block_artifact.rs
+++ b/src/witness/full_block_artifact.rs
@@ -77,8 +77,6 @@ pub struct FullBlockArtifacts<F: SmallField> {
     pub code_decommitter_circuits_data: Vec<CodeDecommitterCircuitInstanceWitness<F>>,
     pub decommittments_deduplicator_circuits_data:
         Vec<CodeDecommittmentsDeduplicatorInstanceWitness<F>>,
-    //
-    pub log_demuxer_circuit_data: Vec<LogDemuxerCircuitInstanceWitness<F>>,
     // IO related circuits
     pub storage_deduplicator_circuit_data: Vec<StorageDeduplicatorInstanceWitness<F>>,
     pub events_deduplicator_circuit_data: Vec<EventsDeduplicatorInstanceWitness<F>>,

--- a/src/witness/individual_circuits/log_demux.rs
+++ b/src/witness/individual_circuits/log_demux.rs
@@ -1,26 +1,53 @@
+use std::sync::Arc;
+
+use self::toolset::GeometryConfig;
+use self::witness::postprocessing::FirstAndLastCircuit;
+
 use super::*;
 use crate::witness::full_block_artifact::LogQueue;
+use crate::witness::postprocessing::CircuitMaker;
 use crate::zkevm_circuits::base_structures::log_query::*;
 use crate::zkevm_circuits::demux_log_queue::input::*;
-use circuit_definitions::encodings::*;
+use circuit_definitions::aux_definitions::witness_oracle::VmWitnessOracle;
+use circuit_definitions::circuit_definitions::base_layer::{
+    LogDemuxInstanceSynthesisFunction, ZkSyncBaseLayerCircuit,
+};
+use circuit_definitions::encodings::recursion_request::RecursionQueueSimulator;
+use circuit_definitions::zkevm_circuits::scheduler::aux::BaseLayerCircuitType;
+use circuit_definitions::{encodings::*, Field, RoundFunction};
 
 /// Take a storage log, output logs separately for events, l1 messages, storage, etc
 pub fn compute_logs_demux<
-    F: SmallField,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4> + AlgebraicRoundFunction<F, 8, 12, 4>,
+    CB: FnMut(ZkSyncBaseLayerCircuit<Field, VmWitnessOracle<Field>, Poseidon2Goldilocks>),
+    QSCB: FnMut(u64, RecursionQueueSimulator<Field>, Vec<ClosedFormInputCompactFormWitness<Field>>),
 >(
-    artifacts: &mut FullBlockArtifacts<F>,
+    artifacts: &mut FullBlockArtifacts<Field>,
     per_circuit_capacity: usize,
-    round_function: &R,
+    round_function: &RoundFunction,
+    geometry: &GeometryConfig,
+    cs_for_witness_generation: &mut ConstraintSystemImpl<Field, RoundFunction>,
+    cycles_used: &mut usize,
+    mut circuit_callback: CB,
+    mut recursion_queue_callback: QSCB,
 ) -> (
-    Vec<LogDemuxerCircuitInstanceWitness<F>>,
-    LogQueue<F>,
-    LogQueue<F>,
-    LogQueue<F>,
-    LogQueue<F>,
-    LogQueue<F>,
-    LogQueue<F>,
+    FirstAndLastCircuit<LogDemuxInstanceSynthesisFunction<GoldilocksField, Poseidon2Goldilocks>>,
+    Vec<ClosedFormInputCompactFormWitness<GoldilocksField>>,
+    LogQueue<Field>,
+    LogQueue<Field>,
+    LogQueue<Field>,
+    LogQueue<Field>,
+    LogQueue<Field>,
+    LogQueue<Field>,
 ) {
+    let circuit_type = BaseLayerCircuitType::LogDemultiplexer;
+
+    let mut maker = CircuitMaker::new(
+        geometry.cycles_per_log_demuxer,
+        Arc::new(round_function.clone()),
+        cs_for_witness_generation,
+        cycles_used,
+    );
+
     // trivial empty case
     if artifacts
         .original_log_queue_simulator
@@ -32,7 +59,7 @@ pub fn compute_logs_demux<
         // return singe dummy witness
         use crate::boojum::gadgets::queue::QueueState;
 
-        let initial_fsm_state = LogDemuxerFSMInputOutput::<F>::placeholder_witness();
+        let initial_fsm_state = LogDemuxerFSMInputOutput::placeholder_witness();
 
         assert_eq!(
             take_queue_state_from_simulator(&artifacts.original_log_queue_simulator),
@@ -42,7 +69,7 @@ pub fn compute_logs_demux<
         let mut passthrough_input = LogDemuxerInputData::placeholder_witness();
         passthrough_input.initial_log_queue_state = QueueState::placeholder_witness();
 
-        let final_fsm_state = LogDemuxerFSMInputOutput::<F>::placeholder_witness();
+        let final_fsm_state = LogDemuxerFSMInputOutput::placeholder_witness();
 
         let passthrough_output = LogDemuxerOutputData::placeholder_witness();
 
@@ -60,8 +87,21 @@ pub fn compute_logs_demux<
             },
         };
 
+        circuit_callback(ZkSyncBaseLayerCircuit::LogDemuxer(
+            maker.process(wit, circuit_type),
+        ));
+
+        let (log_demux_circuits, queue_simulator, log_demux_circuits_compact_forms_witnesses) =
+            maker.into_results();
+        recursion_queue_callback(
+            circuit_type as u64,
+            queue_simulator,
+            log_demux_circuits_compact_forms_witnesses.clone(),
+        );
+
         return (
-            vec![wit],
+            log_demux_circuits,
+            log_demux_circuits_compact_forms_witnesses,
             Default::default(),
             Default::default(),
             Default::default(),
@@ -81,8 +121,6 @@ pub fn compute_logs_demux<
         .is_empty());
     let input_queue_witness = &artifacts.original_log_queue_simulator.witness.as_slices().0;
     let mut states_iter = artifacts.original_log_queue_states.iter();
-
-    let mut results: Vec<LogDemuxerCircuitInstanceWitness<F>> = vec![];
 
     let num_chunks = input_queue_witness.chunks(per_circuit_capacity).len();
 
@@ -123,6 +161,8 @@ pub fn compute_logs_demux<
     let mut demuxed_keccak_precompile_queue = LogQueue::default();
     let mut demuxed_sha256_precompile_queue = LogQueue::default();
     let mut demuxed_ecrecover_queue = LogQueue::default();
+
+    let mut previous_hidden_fsm_output = None;
 
     for (idx, input_chunk) in input_queue_witness.chunks(per_circuit_capacity).enumerate() {
         let is_first = idx == 0;
@@ -255,8 +295,8 @@ pub fn compute_logs_demux<
                 hidden_fsm_output: fsm_output,
             },
             initial_queue_witness: CircuitQueueRawWitness::<
-                F,
-                LogQuery<F>,
+                Field,
+                LogQuery<Field>,
                 4,
                 LOG_QUERY_PACKED_WIDTH,
             > {
@@ -310,13 +350,23 @@ pub fn compute_logs_demux<
             );
         }
 
-        if let Some(previous_witness) = results.last() {
-            witness.closed_form_input.hidden_fsm_input =
-                previous_witness.closed_form_input.hidden_fsm_output.clone();
+        if let Some(output) = previous_hidden_fsm_output {
+            witness.closed_form_input.hidden_fsm_input = output;
         }
+        previous_hidden_fsm_output = Some(witness.closed_form_input.hidden_fsm_output.clone());
 
-        results.push(witness);
+        circuit_callback(ZkSyncBaseLayerCircuit::LogDemuxer(
+            maker.process(witness, circuit_type),
+        ));
     }
+
+    let (log_demux_circuits, queue_simulator, log_demux_circuits_compact_forms_witnesses) =
+        maker.into_results();
+    recursion_queue_callback(
+        circuit_type as u64,
+        queue_simulator,
+        log_demux_circuits_compact_forms_witnesses.clone(),
+    );
 
     assert!(demuxed_rollup_storage_queries_it.next().is_none());
     assert!(demuxed_event_queries_it.next().is_none());
@@ -326,7 +376,8 @@ pub fn compute_logs_demux<
     assert!(demuxed_ecrecover_queries_it.next().is_none());
 
     (
-        results,
+        log_demux_circuits,
+        log_demux_circuits_compact_forms_witnesses,
         demuxed_rollup_storage_queue,
         demuxed_event_queue,
         demuxed_to_l1_queue,

--- a/src/witness/oracle.rs
+++ b/src/witness/oracle.rs
@@ -911,6 +911,11 @@ pub fn create_artifacts_from_tracer<
         }
     }
 
+    let CallstackWithAuxData {
+        flat_new_frames_history,
+        ..
+    } = callstack_with_aux_data;
+
     // we simulate a series of actions on the stack starting from the outermost frame
     // each history record contains an information on what was the stack state between points
     // when it potentially came into and out of scope
@@ -1399,8 +1404,7 @@ pub fn create_artifacts_from_tracer<
             .cloned()
             .collect();
 
-        let callstack_new_frames_witnesses = callstack_with_aux_data
-            .flat_new_frames_history
+        let callstack_new_frames_witnesses = flat_new_frames_history
             .iter()
             .skip_while(|el| el.0 < initial_state.at_cycle)
             .take_while(|el| el.0 < final_state.at_cycle)

--- a/src/witness/oracle.rs
+++ b/src/witness/oracle.rs
@@ -278,9 +278,6 @@ pub fn create_artifacts_from_tracer<
         query_id_into_cycle_index.insert(marker.query_id(), *cycle);
     }
 
-    let num_forwards = forward.len();
-    let num_rollbacks = rollbacks.len();
-
     let mut log_position_mapping = HashMap::new();
 
     let mut demuxed_rollup_storage_queries = vec![];
@@ -353,9 +350,6 @@ pub fn create_artifacts_from_tracer<
 
     // in practice we also split out precompile accesses
 
-    let mut unique_query_id_into_chain_positions: HashMap<u64, usize> =
-        HashMap::with_capacity(num_forwards + num_rollbacks);
-
     tracing::debug!("Running storage log simulation");
 
     for (extended_query, was_applied) in forward.iter().cloned().zip(std::iter::repeat(true)).chain(
@@ -412,9 +406,6 @@ pub fn create_artifacts_from_tracer<
 
         // add renumeration index
         marker_into_queue_position_renumeration_index.insert(query_marker, pointer);
-
-        let query_id = query_marker.query_id();
-        unique_query_id_into_chain_positions.insert(query_id, pointer);
 
         let key = query.timestamp.0;
         if query.rollback {


### PR DESCRIPTION
Lower peak memory use by removing various unused datastructures and optimizing the spike that occurs when generating RAM permutation circuits.

The cause of the spike was that the memory queries are sorted and then put into a queue. This essentially doubles the space requirement of memory queries. However, the memory queue intermediate states take an order of magnitude more memory than the queries and only a few of them are actually required. So I changed the code so that it only keeps those few.