### PR TITLE
make the changes required by new boojum

### DIFF
--- a/circuit_definitions/src/circuit_definitions/aux_layer/mod.rs
+++ b/circuit_definitions/src/circuit_definitions/aux_layer/mod.rs
@@ -148,12 +148,11 @@ impl ZkSyncCompressionLayerCircuit {
         let builder_impl =
             CsReferenceImplementationBuilder::<GoldilocksField, P, ProvingCSConfig>::new(
                 geometry,
-                num_vars.unwrap(),
                 max_trace_len.unwrap(),
             );
         let cs_builder = new_builder::<_, GoldilocksField>(builder_impl);
         let builder = inner.configure_builder_proxy(cs_builder);
-        let mut cs = builder.build(());
+        let mut cs = builder.build(num_vars.unwrap());
         inner.add_tables(&mut cs);
         inner.clone().synthesize_into_cs(&mut cs);
         cs.pad_and_shrink_using_hint(hint);
@@ -459,12 +458,11 @@ impl ZkSyncCompressionForWrapperCircuit {
         let builder_impl =
             CsReferenceImplementationBuilder::<GoldilocksField, P, ProvingCSConfig>::new(
                 geometry,
-                num_vars.unwrap(),
                 max_trace_len.unwrap(),
             );
         let cs_builder = new_builder::<_, GoldilocksField>(builder_impl);
         let builder = inner.configure_builder_proxy(cs_builder);
-        let mut cs = builder.build(());
+        let mut cs = builder.build(num_vars.unwrap());
         inner.add_tables(&mut cs);
         inner.clone().synthesize_into_cs(&mut cs);
         cs.pad_and_shrink_using_hint(hint);

--- a/circuit_definitions/src/circuit_definitions/base_layer/mod.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/mod.rs
@@ -294,12 +294,11 @@ where
         let (max_trace_len, num_vars) = inner.size_hint();
         let builder_impl = CsReferenceImplementationBuilder::<F, P, ProvingCSConfig>::new(
             geometry,
-            num_vars.unwrap(),
             max_trace_len.unwrap(),
         );
         let cs_builder = new_builder::<_, F>(builder_impl);
         let builder = inner.configure_builder_proxy(cs_builder);
-        let mut cs = builder.build(());
+        let mut cs = builder.build(num_vars.unwrap());
         inner.add_tables_proxy(&mut cs);
         inner.clone().synthesize_proxy(&mut cs);
         cs.pad_and_shrink_using_hint(hint);

--- a/circuit_definitions/src/circuit_definitions/recursion_layer/mod.rs
+++ b/circuit_definitions/src/circuit_definitions/recursion_layer/mod.rs
@@ -463,12 +463,11 @@ impl ZkSyncRecursiveLayerCircuit {
         let (max_trace_len, num_vars) = inner.size_hint();
         let builder_impl = CsReferenceImplementationBuilder::<F, P, ProvingCSConfig>::new(
             geometry,
-            num_vars.unwrap(),
             max_trace_len.unwrap(),
         );
         let cs_builder = new_builder::<_, F>(builder_impl);
         let builder = inner.configure_builder_proxy(cs_builder);
-        let mut cs = builder.build(());
+        let mut cs = builder.build(num_vars.unwrap());
         let round_function = ZkSyncDefaultRoundFunction::default();
         inner.add_tables(&mut cs);
         inner.clone().synthesize_into_cs(&mut cs, &round_function);
@@ -486,12 +485,11 @@ impl ZkSyncRecursiveLayerCircuit {
                 let (max_trace_len, num_vars) = inner.size_hint();
                 let builder_impl = CsReferenceImplementationBuilder::<F, P, ProvingCSConfig>::new(
                     geometry,
-                    num_vars.unwrap(),
                     max_trace_len.unwrap(),
                 );
                 let cs_builder = new_builder::<_, F>(builder_impl);
                 let builder = inner.configure_builder_proxy(cs_builder);
-                let mut cs = builder.build(());
+                let mut cs = builder.build(num_vars.unwrap());
                 let round_function = ZkSyncDefaultRoundFunction::default();
                 inner.add_tables(&mut cs);
                 inner.clone().synthesize_into_cs(&mut cs, &round_function);
@@ -503,12 +501,11 @@ impl ZkSyncRecursiveLayerCircuit {
                 let (max_trace_len, num_vars) = inner.size_hint();
                 let builder_impl = CsReferenceImplementationBuilder::<F, P, ProvingCSConfig>::new(
                     geometry,
-                    num_vars.unwrap(),
                     max_trace_len.unwrap(),
                 );
                 let cs_builder = new_builder::<_, F>(builder_impl);
                 let builder = inner.configure_builder_proxy(cs_builder);
-                let mut cs = builder.build(());
+                let mut cs = builder.build(num_vars.unwrap());
                 let round_function = ZkSyncDefaultRoundFunction::default();
                 inner.add_tables(&mut cs);
                 inner.clone().synthesize_into_cs(&mut cs, &round_function);

--- a/src/capacity_estimator.rs
+++ b/src/capacity_estimator.rs
@@ -57,7 +57,6 @@ where
             let builder_impl =
                 CsReferenceImplementationBuilder::<GoldilocksField, P, SetupCSConfig>::new(
                     geometry,
-                    1, // resolver is inactive in this mode
                     1 << max_trace_len_log_2,
                 );
             let builder = new_builder::<_, GoldilocksField>(builder_impl);
@@ -67,11 +66,11 @@ where
             let config = config;
 
             let builder = SF::configure_builder(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(1);
             SF::add_tables(&mut cs);
             let _ = SF::synthesize_into_cs_inner(&mut cs, witness, &round_function, config);
             let (max_trace_len, _) = cs.pad_and_shrink();
-            let cs = cs.into_assembly();
+            let cs = cs.into_assembly::<std::alloc::Global>();
 
             cs.print_gate_stats();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(iter_next_chunk)]
 #![feature(associated_type_defaults)]
 #![feature(return_position_impl_trait_in_trait)]
+#![feature(allocator_api)]
 #![allow(unused_imports)]
 #![allow(clippy::drop_ref)]
 

--- a/src/proof_compression/mod.rs
+++ b/src/proof_compression/mod.rs
@@ -56,16 +56,15 @@ mod test {
 
         let builder_impl = CsReferenceImplementationBuilder::<GoldilocksField, P, DevCSConfig>::new(
             geometry,
-            num_vars.unwrap(),
             max_trace_len.unwrap(),
         );
         let builder = new_builder::<_, GoldilocksField>(builder_impl);
         let builder = circuit.configure_builder_proxy(builder);
-        let mut cs_owned = builder.build(());
+        let mut cs_owned = builder.build(num_vars.unwrap());
         circuit.synthesize_into_cs(&mut cs_owned);
 
         cs_owned.pad_and_shrink();
-        let mut assembly = cs_owned.into_assembly();
+        let mut assembly = cs_owned.into_assembly::<std::alloc::Global>();
         assembly.print_gate_stats();
 
         assert!(assembly.check_if_satisfied(&worker));
@@ -337,16 +336,15 @@ mod test {
 
         let builder_impl = CsReferenceImplementationBuilder::<GoldilocksField, P, DevCSConfig>::new(
             geometry,
-            num_vars.unwrap(),
             max_trace_len.unwrap(),
         );
         let builder = new_builder::<_, GoldilocksField>(builder_impl);
         let builder = circuit.configure_builder_proxy(builder);
-        let mut cs_owned = builder.build(());
+        let mut cs_owned = builder.build(num_vars.unwrap());
         circuit.synthesize_into_cs(&mut cs_owned);
         let _num_gates = cs_owned.pad_and_shrink();
 
-        let mut assembly = cs_owned.into_assembly();
+        let mut assembly = cs_owned.into_assembly::<std::alloc::Global>();
         assembly.print_gate_stats();
 
         assert!(assembly.check_if_satisfied(&worker));

--- a/src/prover_utils.rs
+++ b/src/prover_utils.rs
@@ -64,10 +64,10 @@ pub fn create_base_layer_setup_data(
 
     let geometry = circuit.geometry();
     let (max_trace_len, num_vars) = circuit.size_hint();
+    let num_vars = num_vars.unwrap();
 
     let builder_impl = CsReferenceImplementationBuilder::<GoldilocksField, P, SetupCSConfig>::new(
         geometry,
-        num_vars.unwrap(),
         max_trace_len.unwrap(),
     );
     let builder = new_builder::<_, GoldilocksField>(builder_impl);
@@ -75,15 +75,15 @@ pub fn create_base_layer_setup_data(
     let (cs, finalization_hint) = match circuit {
         ZkSyncBaseLayerCircuit::MainVM(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let (_, finalization_hint) = cs.pad_and_shrink();
-            (cs.into_assembly(), finalization_hint)
+            (cs.into_assembly::<std::alloc::Global>(), finalization_hint)
         }
         ZkSyncBaseLayerCircuit::CodeDecommittmentsSorter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let (_, finalization_hint) = cs.pad_and_shrink();
@@ -91,7 +91,7 @@ pub fn create_base_layer_setup_data(
         }
         ZkSyncBaseLayerCircuit::CodeDecommitter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let (_, finalization_hint) = cs.pad_and_shrink();
@@ -99,7 +99,7 @@ pub fn create_base_layer_setup_data(
         }
         ZkSyncBaseLayerCircuit::LogDemuxer(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let (_, finalization_hint) = cs.pad_and_shrink();
@@ -107,7 +107,7 @@ pub fn create_base_layer_setup_data(
         }
         ZkSyncBaseLayerCircuit::KeccakRoundFunction(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let (_, finalization_hint) = cs.pad_and_shrink();
@@ -115,7 +115,7 @@ pub fn create_base_layer_setup_data(
         }
         ZkSyncBaseLayerCircuit::Sha256RoundFunction(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let (_, finalization_hint) = cs.pad_and_shrink();
@@ -123,7 +123,7 @@ pub fn create_base_layer_setup_data(
         }
         ZkSyncBaseLayerCircuit::ECRecover(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let (_, finalization_hint) = cs.pad_and_shrink();
@@ -131,7 +131,7 @@ pub fn create_base_layer_setup_data(
         }
         ZkSyncBaseLayerCircuit::RAMPermutation(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let (_, finalization_hint) = cs.pad_and_shrink();
@@ -139,7 +139,7 @@ pub fn create_base_layer_setup_data(
         }
         ZkSyncBaseLayerCircuit::StorageSorter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let (_, finalization_hint) = cs.pad_and_shrink();
@@ -147,7 +147,7 @@ pub fn create_base_layer_setup_data(
         }
         ZkSyncBaseLayerCircuit::StorageApplication(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let (_, finalization_hint) = cs.pad_and_shrink();
@@ -155,7 +155,7 @@ pub fn create_base_layer_setup_data(
         }
         ZkSyncBaseLayerCircuit::EventsSorter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let (_, finalization_hint) = cs.pad_and_shrink();
@@ -163,7 +163,7 @@ pub fn create_base_layer_setup_data(
         }
         ZkSyncBaseLayerCircuit::L1MessagesSorter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let (_, finalization_hint) = cs.pad_and_shrink();
@@ -171,7 +171,7 @@ pub fn create_base_layer_setup_data(
         }
         ZkSyncBaseLayerCircuit::L1MessagesHasher(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let (_, finalization_hint) = cs.pad_and_shrink();
@@ -221,10 +221,10 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
 
     let geometry = circuit.geometry();
     let (max_trace_len, num_vars) = circuit.size_hint();
+    let num_vars = num_vars.unwrap();
 
     let builder_impl = CsReferenceImplementationBuilder::<GoldilocksField, P, ProvingCSConfig>::new(
         geometry,
-        num_vars.unwrap(),
         max_trace_len.unwrap(),
     );
     let builder = new_builder::<_, GoldilocksField>(builder_impl);
@@ -232,15 +232,15 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
     let cs = match circuit {
         ZkSyncBaseLayerCircuit::MainVM(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             cs.pad_and_shrink_using_hint(finalization_hint);
-            cs.into_assembly()
+            cs.into_assembly::<std::alloc::Global>()
         }
         ZkSyncBaseLayerCircuit::CodeDecommittmentsSorter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             cs.pad_and_shrink_using_hint(finalization_hint);
@@ -248,7 +248,7 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
         }
         ZkSyncBaseLayerCircuit::CodeDecommitter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             cs.pad_and_shrink_using_hint(finalization_hint);
@@ -256,7 +256,7 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
         }
         ZkSyncBaseLayerCircuit::LogDemuxer(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             cs.pad_and_shrink_using_hint(finalization_hint);
@@ -264,7 +264,7 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
         }
         ZkSyncBaseLayerCircuit::KeccakRoundFunction(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             cs.pad_and_shrink_using_hint(finalization_hint);
@@ -272,7 +272,7 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
         }
         ZkSyncBaseLayerCircuit::Sha256RoundFunction(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             cs.pad_and_shrink_using_hint(finalization_hint);
@@ -280,7 +280,7 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
         }
         ZkSyncBaseLayerCircuit::ECRecover(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             cs.pad_and_shrink_using_hint(finalization_hint);
@@ -288,7 +288,7 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
         }
         ZkSyncBaseLayerCircuit::RAMPermutation(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             cs.pad_and_shrink_using_hint(finalization_hint);
@@ -296,7 +296,7 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
         }
         ZkSyncBaseLayerCircuit::StorageSorter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             cs.pad_and_shrink_using_hint(finalization_hint);
@@ -304,7 +304,7 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
         }
         ZkSyncBaseLayerCircuit::StorageApplication(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             cs.pad_and_shrink_using_hint(finalization_hint);
@@ -312,7 +312,7 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
         }
         ZkSyncBaseLayerCircuit::EventsSorter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             cs.pad_and_shrink_using_hint(finalization_hint);
@@ -320,7 +320,7 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
         }
         ZkSyncBaseLayerCircuit::L1MessagesSorter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             cs.pad_and_shrink_using_hint(finalization_hint);
@@ -328,7 +328,7 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
         }
         ZkSyncBaseLayerCircuit::L1MessagesHasher(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             cs.pad_and_shrink_using_hint(finalization_hint);
@@ -411,10 +411,10 @@ pub fn create_recursive_layer_setup_data(
 
     let geometry = circuit.geometry();
     let (max_trace_len, num_vars) = circuit.size_hint();
+    let num_vars = num_vars.unwrap();
 
     let builder_impl = CsReferenceImplementationBuilder::<GoldilocksField, P, SetupCSConfig>::new(
         geometry,
-        num_vars.unwrap(),
         max_trace_len.unwrap(),
     );
     let builder = new_builder::<_, GoldilocksField>(builder_impl);
@@ -422,19 +422,19 @@ pub fn create_recursive_layer_setup_data(
     let (cs, finalization_hint) = match circuit {
         ZkSyncRecursiveLayerCircuit::SchedulerCircuit(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables(&mut cs);
             inner.synthesize_into_cs(&mut cs, &round_function);
             let (_, finalization_hint) = cs.pad_and_shrink();
-            (cs.into_assembly(), finalization_hint)
+            (cs.into_assembly::<std::alloc::Global>(), finalization_hint)
         }
         ZkSyncRecursiveLayerCircuit::NodeLayerCircuit(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables(&mut cs);
             inner.synthesize_into_cs(&mut cs, &round_function);
             let (_, finalization_hint) = cs.pad_and_shrink();
-            (cs.into_assembly(), finalization_hint)
+            (cs.into_assembly::<std::alloc::Global>(), finalization_hint)
         }
         ZkSyncRecursiveLayerCircuit::LeafLayerCircuitForMainVM(inner)
         | ZkSyncRecursiveLayerCircuit::LeafLayerCircuitForCodeDecommittmentsSorter(inner)
@@ -450,7 +450,7 @@ pub fn create_recursive_layer_setup_data(
         | ZkSyncRecursiveLayerCircuit::LeafLayerCircuitForL1MessagesSorter(inner)
         | ZkSyncRecursiveLayerCircuit::LeafLayerCircuitForL1MessagesHasher(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables(&mut cs);
             inner.synthesize_into_cs(&mut cs, &round_function);
             let (_, finalization_hint) = cs.pad_and_shrink();
@@ -492,10 +492,10 @@ pub fn prove_recursion_layer_circuit<POW: PoWRunner>(
 
     let geometry = circuit.geometry();
     let (max_trace_len, num_vars) = circuit.size_hint();
+    let num_vars = num_vars.unwrap();
 
     let builder_impl = CsReferenceImplementationBuilder::<GoldilocksField, P, ProvingCSConfig>::new(
         geometry,
-        num_vars.unwrap(),
         max_trace_len.unwrap(),
     );
     let builder = new_builder::<_, GoldilocksField>(builder_impl);
@@ -503,19 +503,19 @@ pub fn prove_recursion_layer_circuit<POW: PoWRunner>(
     let cs = match circuit {
         ZkSyncRecursiveLayerCircuit::SchedulerCircuit(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables(&mut cs);
             inner.synthesize_into_cs(&mut cs, &round_function);
             cs.pad_and_shrink_using_hint(finalization_hint);
-            cs.into_assembly()
+            cs.into_assembly::<std::alloc::Global>()
         }
         ZkSyncRecursiveLayerCircuit::NodeLayerCircuit(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables(&mut cs);
             inner.synthesize_into_cs(&mut cs, &round_function);
             cs.pad_and_shrink_using_hint(finalization_hint);
-            cs.into_assembly()
+            cs.into_assembly::<std::alloc::Global>()
         }
         ZkSyncRecursiveLayerCircuit::LeafLayerCircuitForMainVM(inner)
         | ZkSyncRecursiveLayerCircuit::LeafLayerCircuitForCodeDecommittmentsSorter(inner)
@@ -531,7 +531,7 @@ pub fn prove_recursion_layer_circuit<POW: PoWRunner>(
         | ZkSyncRecursiveLayerCircuit::LeafLayerCircuitForL1MessagesSorter(inner)
         | ZkSyncRecursiveLayerCircuit::LeafLayerCircuitForL1MessagesHasher(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables(&mut cs);
             inner.synthesize_into_cs(&mut cs, &round_function);
             cs.pad_and_shrink_using_hint(finalization_hint);
@@ -605,13 +605,12 @@ pub fn create_compression_layer_setup_data(
         let builder_impl =
             CsReferenceImplementationBuilder::<GoldilocksField, P, SetupCSConfig>::new(
                 geometry,
-                num_vars.unwrap(),
                 max_trace_len.unwrap(),
             );
         let builder = new_builder::<_, GoldilocksField>(builder_impl);
 
         let builder = circuit.configure_builder_proxy(builder);
-        let mut cs = builder.build(());
+        let mut cs = builder.build(num_vars.unwrap());
         circuit.add_tables(&mut cs);
         circuit.synthesize_into_cs(&mut cs);
         let (_, finalization_hint) = cs.pad_and_shrink();
@@ -667,12 +666,11 @@ pub fn prove_compression_layer_circuit<POW: PoWRunner>(
             CsReferenceImplementationBuilder::<GoldilocksField, P, ProvingCSConfig>::new(
                 geometry,
                 num_vars.unwrap(),
-                max_trace_len.unwrap(),
             );
         let builder = new_builder::<_, GoldilocksField>(builder_impl);
 
         let builder = circuit.configure_builder_proxy(builder);
-        let mut cs = builder.build(());
+        let mut cs = builder.build(num_vars.unwrap());
         circuit.add_tables(&mut cs);
         circuit.synthesize_into_cs(&mut cs);
         cs.pad_and_shrink_using_hint(finalization_hint);
@@ -756,13 +754,12 @@ pub fn create_compression_for_wrapper_setup_data(
         let builder_impl =
             CsReferenceImplementationBuilder::<GoldilocksField, P, SetupCSConfig>::new(
                 geometry,
-                num_vars.unwrap(),
                 max_trace_len.unwrap(),
             );
         let builder = new_builder::<_, GoldilocksField>(builder_impl);
 
         let builder = circuit.configure_builder_proxy(builder);
-        let mut cs = builder.build(());
+        let mut cs = builder.build(num_vars.unwrap());
         circuit.add_tables(&mut cs);
         circuit.synthesize_into_cs(&mut cs);
         let (_, finalization_hint) = cs.pad_and_shrink();
@@ -827,13 +824,12 @@ pub fn prove_compression_for_wrapper_circuit<POW: PoWRunner>(
         let builder_impl =
             CsReferenceImplementationBuilder::<GoldilocksField, P, ProvingCSConfig>::new(
                 geometry,
-                num_vars.unwrap(),
                 max_trace_len.unwrap(),
             );
         let builder = new_builder::<_, GoldilocksField>(builder_impl);
 
         let builder = circuit.configure_builder_proxy(builder);
-        let mut cs = builder.build(());
+        let mut cs = builder.build(num_vars.unwrap());
         circuit.add_tables(&mut cs);
         circuit.synthesize_into_cs(&mut cs);
         cs.pad_and_shrink_using_hint(finalization_hint);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -111,10 +111,10 @@ pub(crate) fn base_test_circuit(
 
     let geometry = circuit.geometry();
     let (max_trace_len, num_vars) = circuit.size_hint();
+    let num_vars = num_vars.unwrap();
 
     let builder_impl = CsReferenceImplementationBuilder::<GoldilocksField, P, DevCSConfig>::new(
         geometry,
-        num_vars.unwrap(),
         max_trace_len.unwrap(),
     );
     let builder = new_builder::<_, GoldilocksField>(builder_impl);
@@ -122,15 +122,15 @@ pub(crate) fn base_test_circuit(
     let mut cs = match circuit {
         ZkSyncBaseLayerCircuit::MainVM(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let _ = cs.pad_and_shrink();
-            cs.into_assembly()
+            cs.into_assembly::<std::alloc::Global>()
         }
         ZkSyncBaseLayerCircuit::CodeDecommittmentsSorter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let _ = cs.pad_and_shrink();
@@ -138,7 +138,7 @@ pub(crate) fn base_test_circuit(
         }
         ZkSyncBaseLayerCircuit::CodeDecommitter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let _ = cs.pad_and_shrink();
@@ -146,7 +146,7 @@ pub(crate) fn base_test_circuit(
         }
         ZkSyncBaseLayerCircuit::LogDemuxer(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let _ = cs.pad_and_shrink();
@@ -154,7 +154,7 @@ pub(crate) fn base_test_circuit(
         }
         ZkSyncBaseLayerCircuit::KeccakRoundFunction(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let _ = cs.pad_and_shrink();
@@ -162,7 +162,7 @@ pub(crate) fn base_test_circuit(
         }
         ZkSyncBaseLayerCircuit::Sha256RoundFunction(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let _ = cs.pad_and_shrink();
@@ -170,7 +170,7 @@ pub(crate) fn base_test_circuit(
         }
         ZkSyncBaseLayerCircuit::ECRecover(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let _ = cs.pad_and_shrink();
@@ -178,7 +178,7 @@ pub(crate) fn base_test_circuit(
         }
         ZkSyncBaseLayerCircuit::RAMPermutation(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let _ = cs.pad_and_shrink();
@@ -186,7 +186,7 @@ pub(crate) fn base_test_circuit(
         }
         ZkSyncBaseLayerCircuit::StorageSorter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let _ = cs.pad_and_shrink();
@@ -194,7 +194,7 @@ pub(crate) fn base_test_circuit(
         }
         ZkSyncBaseLayerCircuit::StorageApplication(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let _ = cs.pad_and_shrink();
@@ -202,7 +202,7 @@ pub(crate) fn base_test_circuit(
         }
         ZkSyncBaseLayerCircuit::EventsSorter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let _ = cs.pad_and_shrink();
@@ -210,7 +210,7 @@ pub(crate) fn base_test_circuit(
         }
         ZkSyncBaseLayerCircuit::L1MessagesSorter(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let _ = cs.pad_and_shrink();
@@ -218,7 +218,7 @@ pub(crate) fn base_test_circuit(
         }
         ZkSyncBaseLayerCircuit::L1MessagesHasher(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables_proxy(&mut cs);
             inner.synthesize_proxy(&mut cs);
             let _ = cs.pad_and_shrink();
@@ -242,10 +242,10 @@ pub(crate) fn test_recursive_circuit(circuit: ZkSyncRecursiveLayerCircuit) {
 
     let geometry = circuit.geometry();
     let (max_trace_len, num_vars) = circuit.size_hint();
+    let num_vars = num_vars.unwrap();
 
     let builder_impl = CsReferenceImplementationBuilder::<GoldilocksField, P, DevCSConfig>::new(
         geometry,
-        num_vars.unwrap(),
         max_trace_len.unwrap(),
     );
     let builder = new_builder::<_, GoldilocksField>(builder_impl);
@@ -254,15 +254,15 @@ pub(crate) fn test_recursive_circuit(circuit: ZkSyncRecursiveLayerCircuit) {
     let mut cs = match circuit {
         ZkSyncRecursiveLayerCircuit::SchedulerCircuit(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables(&mut cs);
             inner.synthesize_into_cs(&mut cs, &round_function);
             let _ = cs.pad_and_shrink();
-            cs.into_assembly()
+            cs.into_assembly::<std::alloc::Global>()
         }
         ZkSyncRecursiveLayerCircuit::NodeLayerCircuit(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables(&mut cs);
             inner.synthesize_into_cs(&mut cs, &round_function);
             let _ = cs.pad_and_shrink();
@@ -282,7 +282,7 @@ pub(crate) fn test_recursive_circuit(circuit: ZkSyncRecursiveLayerCircuit) {
         | ZkSyncRecursiveLayerCircuit::LeafLayerCircuitForL1MessagesSorter(inner)
         | ZkSyncRecursiveLayerCircuit::LeafLayerCircuitForL1MessagesHasher(inner) => {
             let builder = inner.configure_builder_proxy(builder);
-            let mut cs = builder.build(());
+            let mut cs = builder.build(num_vars);
             inner.add_tables(&mut cs);
             inner.synthesize_into_cs(&mut cs, &round_function);
             let _ = cs.pad_and_shrink();
@@ -316,18 +316,11 @@ pub(crate) fn test_compression_circuit(circuit: ZkSyncCompressionLayerCircuit) {
 
         let builder_impl = CsReferenceImplementationBuilder::<GoldilocksField, P, DevCSConfig>::new(
             geometry,
-            num_vars.unwrap(),
-            max_trace_len.unwrap(),
-        );
-        let builder = new_builder::<_, GoldilocksField>(builder_impl);
-        let builder_impl = CsReferenceImplementationBuilder::<GoldilocksField, P, DevCSConfig>::new(
-            geometry,
-            num_vars.unwrap(),
             max_trace_len.unwrap(),
         );
         let builder = new_builder::<_, GoldilocksField>(builder_impl);
         let builder = circuit.configure_builder_proxy(builder);
-        let mut cs = builder.build(());
+        let mut cs = builder.build(num_vars.unwrap());
         circuit.synthesize_into_cs(&mut cs);
 
         cs.pad_and_shrink();
@@ -367,18 +360,11 @@ pub(crate) fn test_compression_for_wrapper_circuit(circuit: ZkSyncCompressionFor
 
         let builder_impl = CsReferenceImplementationBuilder::<GoldilocksField, P, DevCSConfig>::new(
             geometry,
-            num_vars.unwrap(),
-            max_trace_len.unwrap(),
-        );
-        let builder = new_builder::<_, GoldilocksField>(builder_impl);
-        let builder_impl = CsReferenceImplementationBuilder::<GoldilocksField, P, DevCSConfig>::new(
-            geometry,
-            num_vars.unwrap(),
             max_trace_len.unwrap(),
         );
         let builder = new_builder::<_, GoldilocksField>(builder_impl);
         let builder = circuit.configure_builder_proxy(builder);
-        let mut cs = builder.build(());
+        let mut cs = builder.build(num_vars.unwrap());
         circuit.synthesize_into_cs(&mut cs);
 
         cs.pad_and_shrink();

--- a/src/witness/utils.rs
+++ b/src/witness/utils.rs
@@ -178,11 +178,8 @@ pub fn create_cs_for_witness_generation<
 
     use crate::boojum::cs::cs_builder_reference::CsReferenceImplementationBuilder;
 
-    let builder_impl = CsReferenceImplementationBuilder::<F, F, ProvingCSConfig>::new(
-        geometry,
-        num_vars,
-        max_trace_len,
-    );
+    let builder_impl =
+        CsReferenceImplementationBuilder::<F, F, ProvingCSConfig>::new(geometry, max_trace_len);
     let builder = boojum::cs::cs_builder::new_builder::<_, F>(builder_impl);
     let builder = builder.allow_lookup(
         boojum::cs::LookupParameters::UseSpecializedColumnsWithTableIdAsConstant {
@@ -212,7 +209,7 @@ pub fn create_cs_for_witness_generation<
     let builder =
         SelectionGate::configure_builder(builder, GatePlacementStrategy::UseGeneralPurposeColumns);
 
-    let mut cs = builder.build(());
+    let mut cs = builder.build(num_vars);
 
     use crate::boojum::cs::traits::cs::ConstraintSystem;
     use crate::boojum::gadgets::tables::*;


### PR DESCRIPTION
Boojum API changed but the version wasn't bumped. Because of that this change is needed to be able to depend on old harness versions in core.