### PR TITLE
fix: Fixing read_basic_artifacts

### DIFF
--- a/src/compute_setups.rs
+++ b/src/compute_setups.rs
@@ -37,7 +37,7 @@ use crate::prover_utils::*;
 pub fn generate_base_layer_vks_and_proofs(
     source: &mut dyn SetupDataSource,
 ) -> crate::data_source::SourceResult<()> {
-    let test_artifact = read_basic_test_artifact();
+    let test_artifact = read_basic_test_artifacts_cached();
     let geometry = crate::geometry_config::get_geometry_config();
     let (base_layer_circuit, _, _) = generate_base_layer(test_artifact, 20000, geometry);
 

--- a/src/tests/complex_tests/utils.rs
+++ b/src/tests/complex_tests/utils.rs
@@ -27,6 +27,7 @@ const TEST_CONTRACT_FILE_NAMES: [&str; 4] = [
     "Main.sol",
 ];
 const SYSTEM_CONTRACTS_BRANCH: &str = "v1-4-1-integration";
+// TODO: This is not a correct location anymore, as we migrated the system contracts into era-contracts.
 const SYSTEM_CONTRACTS_URL: &str = "https://github.com/matter-labs/era-system-contracts/";
 const SYSTEM_CONTRACTS_COMMITS_URL: &str =
     "https://api.github.com/repos/matter-labs/era-system-contracts/commits/";
@@ -98,6 +99,16 @@ struct CompilerMetadata {
     zksolc_compiler_version: String,
 }
 
+/// Reads the basic test artifacts that was created during compilation.
+pub fn read_basic_test_artifacts_cached() -> TestArtifact {
+    let basic_test_bytes = include_bytes!("test_artifacts/basic_test.json");
+    let text = std::str::from_utf8(basic_test_bytes)
+        .expect("basic test json should be utf8 encoded string");
+    serde_json::from_str(text).unwrap()
+}
+
+/// Reads & updates the basic test artifacts (test contracts, system contracts etc).
+/// WARNING: If running this, make sure to run within test_harness directory.
 pub fn read_basic_test_artifact() -> TestArtifact {
     let current_compiler_metadata = CompilerMetadata {
         solc_compiler_version: SOLC_VERSION.to_owned(),


### PR DESCRIPTION
# What ❔

* Basic artifacts file is a collection of bytecodes and sample contracts.
* They are used in multiple tests AND are also using during verification key generation
* Normally they are submitted in this repository, but the current logic was also trying to refresh them at the same time (fetching newer version from github etc)
* I've created a separate method, that simply reads the currently available artifacts, when we are creating verification keys.

## Why ❔

* This makes verification key process more hermetic.
* Also the current code didn't really work when it was invoked from outside of this directory (as it depended on local file location) - which resulted in contracts being recompiled every time.

## Followups
It also seems that the contracts are being read from the wrong location (we migrated from era-system-contracts to era-contracts couple months back) - but this will be fixed in a separate PR