### PR TITLE
chore: Make check_trusted_setup method public

### DIFF
--- a/src/proof_wrapper_utils/utils.rs
+++ b/src/proof_wrapper_utils/utils.rs
@@ -3,18 +3,20 @@ use super::*;
 pub(crate) const CRS_FILE_ENV_VAR: &str = "CRS_FILE";
 
 /// Just to check if the file and environment variable are not forgotten
-pub(crate) fn check_trusted_setup_file_existace() {
-    let crs_file_str = std::env::var(CRS_FILE_ENV_VAR).expect("crs file env var");
+pub fn check_trusted_setup_file_existace() {
+    let crs_file_str = std::env::var(CRS_FILE_ENV_VAR).expect("CRS_FILE env variable:");
     let crs_file_path = std::path::Path::new(&crs_file_str);
-    let _crs_file = std::fs::File::open(&crs_file_path).expect("crs file to open");
+    let _crs_file = std::fs::File::open(&crs_file_path)
+        .expect(format!("Trying to open CRS FILE: {:?}", crs_file_path).as_str());
 }
 
 /// Uploads trusted setup file to the RAM
 pub fn get_trusted_setup() -> Crs<Bn256, CrsForMonomialForm> {
-    let crs_file_str = std::env::var(CRS_FILE_ENV_VAR).expect("crs file env var");
+    let crs_file_str = std::env::var(CRS_FILE_ENV_VAR).expect("CRS_FILE env variable:");
     let crs_file_path = std::path::Path::new(&crs_file_str);
-    let crs_file = std::fs::File::open(&crs_file_path).expect("crs file to open");
-    Crs::read(&crs_file).expect("crs file for bases")
+    let crs_file = std::fs::File::open(&crs_file_path)
+        .expect(format!("Trying to open CRS FILE: {:?}", crs_file_path).as_str());
+    Crs::read(&crs_file).expect(format!("Trying to read CRS FILE: {:?}", crs_file_path).as_str())
 }
 
 /// Computes wrapper public input from stark one


### PR DESCRIPTION
# What ❔

* Making check_trusted_setup public
* Adding clear error messages

## Why ❔

* currently this check is done only once we compute the snark wrapper - and this is done in the later phase of the verification key computation
* this means that if the user didn't set the env variable, the process will fail after 30 minutes.
* After this PR, the verification key process can fail immediately (after we do the change to the code in zksync-era to use this function).
