### PR TITLE
feat: Added method to generate setup data 

### DIFF
--- a/src/compute_setups.rs
+++ b/src/compute_setups.rs
@@ -4,7 +4,6 @@ use std::{
     sync::Arc,
 };
 
-use crate::boojum::worker::Worker;
 use circuit_definitions::boojum::gadgets::traits::allocatable::CSAllocatable;
 use circuit_definitions::{
     aux_definitions::witness_oracle::VmWitnessOracle,
@@ -27,16 +26,21 @@ use crossbeam::atomic::AtomicCell;
 use self::toolset::GeometryConfig;
 
 use super::*;
-use crate::boojum::algebraic_props::round_function::AbsorptionModeOverwrite;
-use crate::boojum::algebraic_props::sponge::GoldilocksPoseidon2Sponge;
-use crate::boojum::cs::implementations::hints::DenseVariablesCopyHint;
-use crate::boojum::cs::implementations::hints::DenseWitnessCopyHint;
-use crate::boojum::cs::implementations::polynomial_storage::{SetupBaseStorage, SetupStorage};
-use crate::boojum::cs::implementations::pow::NoPow;
-use crate::boojum::cs::implementations::prover::ProofConfig;
-use crate::boojum::cs::implementations::setup::FinalizationHintsForProver;
-use crate::boojum::cs::implementations::verifier::VerificationKey;
-use crate::boojum::cs::oracle::merkle_tree::MerkleTreeWithCap;
+use crate::boojum::{
+    algebraic_props::{round_function::AbsorptionModeOverwrite, sponge::GoldilocksPoseidon2Sponge},
+    cs::{
+        implementations::{
+            hints::{DenseVariablesCopyHint, DenseWitnessCopyHint},
+            polynomial_storage::{SetupBaseStorage, SetupStorage},
+            pow::NoPow,
+            prover::ProofConfig,
+            setup::FinalizationHintsForProver,
+            verifier::VerificationKey,
+        },
+        oracle::merkle_tree::MerkleTreeWithCap,
+    },
+    worker::Worker,
+};
 
 use crate::data_source::SetupDataSource;
 use crate::tests::complex_tests::generate_base_layer;

--- a/src/compute_setups.rs
+++ b/src/compute_setups.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use crate::boojum::worker::Worker;
+use circuit_definitions::boojum::gadgets::traits::allocatable::CSAllocatable;
 use circuit_definitions::{
     aux_definitions::witness_oracle::VmWitnessOracle,
     circuit_definitions::{
@@ -14,16 +15,27 @@ use circuit_definitions::{
         },
         ZkSyncUniformCircuitInstance,
     },
-    recursion_layer_proof_config, RECURSION_LAYER_CAP_SIZE, RECURSION_LAYER_FRI_LDE_FACTOR,
+    recursion_layer_proof_config,
+    zkevm_circuits::scheduler::aux::BaseLayerCircuitType,
+    RECURSION_LAYER_CAP_SIZE, RECURSION_LAYER_FRI_LDE_FACTOR,
 };
+
 use crossbeam::atomic::AtomicCell;
 
 use self::toolset::GeometryConfig;
 
 use super::*;
-
+use crate::boojum::algebraic_props::round_function::AbsorptionModeOverwrite;
+use crate::boojum::algebraic_props::sponge::GoldilocksPoseidon2Sponge;
+use crate::boojum::cs::implementations::hints::DenseVariablesCopyHint;
+use crate::boojum::cs::implementations::hints::DenseWitnessCopyHint;
+use crate::boojum::cs::implementations::polynomial_storage::{SetupBaseStorage, SetupStorage};
 use crate::boojum::cs::implementations::pow::NoPow;
 use crate::boojum::cs::implementations::prover::ProofConfig;
+use crate::boojum::cs::implementations::setup::FinalizationHintsForProver;
+use crate::boojum::cs::implementations::verifier::VerificationKey;
+use crate::boojum::cs::oracle::merkle_tree::MerkleTreeWithCap;
+
 use crate::data_source::SetupDataSource;
 use crate::tests::complex_tests::generate_base_layer;
 use crate::zkevm_circuits::base_structures::vm_state::{
@@ -132,6 +144,221 @@ fn get_all_basic_circuits(
     ]
 }
 
+/// Returns all the recursive circuits (including leaves, nodes and scheduler).
+/// Source must contain the verification keys for basic layer, leaf and node.
+fn get_all_recursive_circuits(
+    source: &mut dyn SetupDataSource,
+) -> crate::data_source::SourceResult<Vec<ZkSyncRecursiveLayerCircuit>> {
+    let mut result = get_leaf_circuits(source)?;
+
+    result.push(get_node_circuit(source)?);
+    result.push(get_scheduler_circuit(source)?);
+    return Ok(result);
+}
+
+/// Returns all the leaf circuits.
+fn get_leaf_circuits(
+    source: &mut dyn SetupDataSource,
+) -> crate::data_source::SourceResult<Vec<ZkSyncRecursiveLayerCircuit>> {
+    let mut result = vec![];
+
+    for base_circuit_type in
+        (BaseLayerCircuitType::VM as u8)..=(BaseLayerCircuitType::L1MessagesHasher as u8)
+    {
+        let recursive_circuit_type = base_circuit_type_into_recursive_leaf_circuit_type(
+            BaseLayerCircuitType::from_numeric_value(base_circuit_type),
+        );
+
+        println!(
+            "Computing leaf layer VK for type {:?}",
+            recursive_circuit_type
+        );
+        use crate::zkevm_circuits::recursion::leaf_layer::input::*;
+        let input = RecursionLeafInput::placeholder_witness();
+        let vk = source.get_base_layer_vk(base_circuit_type)?;
+
+        use crate::boojum::gadgets::queue::full_state_queue::FullStateCircuitQueueRawWitness;
+        let witness = RecursionLeafInstanceWitness {
+            input,
+            vk_witness: vk.clone().into_inner(),
+            queue_witness: FullStateCircuitQueueRawWitness {
+                elements: VecDeque::new(),
+            },
+            proof_witnesses: VecDeque::new(),
+        };
+
+        use crate::zkevm_circuits::recursion::leaf_layer::LeafLayerRecursionConfig;
+        let config = LeafLayerRecursionConfig {
+            proof_config: recursion_layer_proof_config(),
+            vk_fixed_parameters: vk.into_inner().fixed_parameters,
+            capacity: RECURSION_ARITY,
+            _marker: std::marker::PhantomData,
+        };
+
+        let circuit = ZkSyncLeafLayerRecursiveCircuit {
+            base_layer_circuit_type: BaseLayerCircuitType::from_numeric_value(base_circuit_type),
+            witness: witness,
+            config: config,
+            transcript_params: (),
+            _marker: std::marker::PhantomData,
+        };
+
+        let circuit = ZkSyncRecursiveLayerCircuit::leaf_circuit_from_base_type(
+            BaseLayerCircuitType::from_numeric_value(base_circuit_type),
+            circuit,
+        );
+        result.push(circuit);
+    }
+    return Ok(result);
+}
+
+/// Returns the node circuit.
+/// Source must contain the leaf verification key (for at least one).
+fn get_node_circuit(
+    source: &mut dyn SetupDataSource,
+) -> crate::data_source::SourceResult<ZkSyncRecursiveLayerCircuit> {
+    use crate::zkevm_circuits::recursion::node_layer::input::*;
+    let input = RecursionNodeInput::placeholder_witness();
+    let vk = source
+        .get_recursion_layer_vk(ZkSyncRecursionLayerStorageType::LeafLayerCircuitForMainVM as u8)?;
+
+    // the only thing to setup here is to have proper number of split points
+    use crate::boojum::gadgets::queue::QueueTailState;
+    let split_points = vec![
+            QueueTailState::<GoldilocksField, FULL_SPONGE_QUEUE_STATE_WIDTH>::placeholder_witness();
+            RECURSION_ARITY - 1
+        ];
+    let witness = RecursionNodeInstanceWitness {
+        input,
+        vk_witness: vk.clone().into_inner(),
+        split_points: split_points.into(),
+        proof_witnesses: VecDeque::new(),
+    };
+
+    use crate::zkevm_circuits::recursion::node_layer::NodeLayerRecursionConfig;
+    use circuit_definitions::circuit_definitions::recursion_layer::node_layer::ZkSyncNodeLayerRecursiveCircuit;
+    let config = NodeLayerRecursionConfig {
+        proof_config: recursion_layer_proof_config(),
+        vk_fixed_parameters: vk.into_inner().fixed_parameters,
+        leaf_layer_capacity: RECURSION_ARITY,
+        node_layer_capacity: RECURSION_ARITY,
+        _marker: std::marker::PhantomData,
+    };
+    let circuit = ZkSyncNodeLayerRecursiveCircuit {
+        witness,
+        config,
+        transcript_params: (),
+        _marker: std::marker::PhantomData,
+    };
+
+    Ok(ZkSyncRecursiveLayerCircuit::NodeLayerCircuit(circuit))
+}
+
+/// Returns the scheduler circuit.
+/// Source must contain the node verification key.
+fn get_scheduler_circuit(
+    source: &mut dyn SetupDataSource,
+) -> crate::data_source::SourceResult<ZkSyncRecursiveLayerCircuit> {
+    use crate::zkevm_circuits::scheduler::SchedulerConfig;
+    use circuit_definitions::circuit_definitions::recursion_layer::scheduler::SchedulerCircuit;
+
+    let node_vk = source.get_recursion_layer_node_vk()?.into_inner();
+
+    let config = SchedulerConfig {
+        proof_config: recursion_layer_proof_config(),
+        vk_fixed_parameters: node_vk.fixed_parameters.clone(),
+        capacity: SCHEDULER_CAPACITY,
+        _marker: std::marker::PhantomData,
+    };
+
+    use crate::zkevm_circuits::scheduler::input::SchedulerCircuitInstanceWitness;
+    let mut scheduler_witness = SchedulerCircuitInstanceWitness::placeholder();
+    // the only thing we need to setup here is a VK
+    scheduler_witness.node_layer_vk_witness = node_vk;
+
+    let scheduler_circuit = SchedulerCircuit {
+        witness: scheduler_witness,
+        config,
+        transcript_params: (),
+        eip4844_proof_config: None,
+        eip4844_vk_fixed_parameters: None,
+        eip4844_vk: None,
+        _marker: std::marker::PhantomData,
+    };
+
+    Ok(ZkSyncRecursiveLayerCircuit::SchedulerCircuit(
+        scheduler_circuit,
+    ))
+}
+
+/// Contains all the information that prover needs to setup and verify the given circuit.
+pub struct CircuitSetupData {
+    pub setup_base: SetupBaseStorage<GoldilocksField, GoldilocksField>,
+    pub setup: SetupStorage<GoldilocksField, GoldilocksField>,
+    pub vk: VerificationKey<GoldilocksField, GoldilocksPoseidon2Sponge<AbsorptionModeOverwrite>>,
+    pub setup_tree:
+        MerkleTreeWithCap<GoldilocksField, GoldilocksPoseidon2Sponge<AbsorptionModeOverwrite>>,
+    pub vars_hint: DenseVariablesCopyHint,
+    pub wits_hint: DenseWitnessCopyHint,
+    pub finalization_hint: FinalizationHintsForProver,
+}
+
+/// Generate verification, and setup keys for a given circuit type from a base layer.
+/// If generating the setup data for recursion layers, the 'source' must have verification keys for basic circuits, leaf and node.
+pub fn generate_circuit_setup_data(
+    is_base_layer: bool,
+    circuit_type: u8,
+    source: &mut dyn SetupDataSource,
+) -> crate::data_source::SourceResult<CircuitSetupData> {
+    let geometry = crate::geometry_config::get_geometry_config();
+    let worker = Worker::new();
+
+    let (setup_base, setup, vk, setup_tree, vars_hint, wits_hint, finalization_hint) =
+        if is_base_layer {
+            let circuit = get_all_basic_circuits(&geometry)
+                .iter()
+                .find(|circuit| circuit.numeric_circuit_type() == circuit_type)
+                .expect(&format!(
+                    "Could not find circuit matching {:?}",
+                    circuit_type
+                ))
+                .clone();
+
+            create_base_layer_setup_data(
+                circuit,
+                &worker,
+                BASE_LAYER_FRI_LDE_FACTOR,
+                BASE_LAYER_CAP_SIZE,
+            )
+        } else {
+            let circuit = get_all_recursive_circuits(source)?
+                .iter()
+                .find(|circuit| circuit.numeric_circuit_type() == circuit_type)
+                .expect(&format!(
+                    "Could not find circuit matching {:?}",
+                    circuit_type
+                ))
+                .clone();
+
+            create_recursive_layer_setup_data(
+                circuit,
+                &worker,
+                BASE_LAYER_FRI_LDE_FACTOR,
+                BASE_LAYER_CAP_SIZE,
+            )
+        };
+
+    Ok(CircuitSetupData {
+        setup_base,
+        setup,
+        vk,
+        setup_tree,
+        vars_hint,
+        wits_hint,
+        finalization_hint,
+    })
+}
+
 /// For backwards compatibility (as zksync-era uses this method).
 /// For new cases please use generate_base_layer_vks directly.
 pub fn generate_base_layer_vks_and_proofs(
@@ -180,51 +407,10 @@ pub fn generate_recursive_layer_vks_and_proofs(
     let worker = Worker::new();
 
     println!("Computing leaf vks");
-
-    for base_circuit_type in
-        (BaseLayerCircuitType::VM as u8)..=(BaseLayerCircuitType::L1MessagesHasher as u8)
-    {
-        let recursive_circuit_type = base_circuit_type_into_recursive_leaf_circuit_type(
-            BaseLayerCircuitType::from_numeric_value(base_circuit_type),
-        );
-
+    for circuit in get_leaf_circuits(source)? {
         println!(
             "Computing leaf layer VK for type {:?}",
-            recursive_circuit_type
-        );
-        use crate::zkevm_circuits::recursion::leaf_layer::input::*;
-        let input = RecursionLeafInput::placeholder_witness();
-        let vk = source.get_base_layer_vk(base_circuit_type)?;
-
-        use crate::boojum::gadgets::queue::full_state_queue::FullStateCircuitQueueRawWitness;
-        let witness = RecursionLeafInstanceWitness {
-            input,
-            vk_witness: vk.clone().into_inner(),
-            queue_witness: FullStateCircuitQueueRawWitness {
-                elements: VecDeque::new(),
-            },
-            proof_witnesses: VecDeque::new(),
-        };
-
-        use crate::zkevm_circuits::recursion::leaf_layer::LeafLayerRecursionConfig;
-        let config = LeafLayerRecursionConfig {
-            proof_config: recursion_layer_proof_config(),
-            vk_fixed_parameters: vk.into_inner().fixed_parameters,
-            capacity: RECURSION_ARITY,
-            _marker: std::marker::PhantomData,
-        };
-
-        let circuit = ZkSyncLeafLayerRecursiveCircuit {
-            base_layer_circuit_type: BaseLayerCircuitType::from_numeric_value(base_circuit_type),
-            witness: witness,
-            config: config,
-            transcript_params: (),
-            _marker: std::marker::PhantomData,
-        };
-
-        let circuit = ZkSyncRecursiveLayerCircuit::leaf_circuit_from_base_type(
-            BaseLayerCircuitType::from_numeric_value(base_circuit_type),
-            circuit,
+            circuit.numeric_circuit_type()
         );
 
         let (setup_base, setup, vk, setup_tree, vars_hint, wits_hint, finalization_hint) =
@@ -236,12 +422,12 @@ pub fn generate_recursive_layer_vks_and_proofs(
             );
 
         let typed_finalization_hint = ZkSyncRecursionLayerFinalizationHint::from_inner(
-            recursive_circuit_type as u8,
+            circuit.numeric_circuit_type(),
             finalization_hint.clone(),
         );
         source.set_recursion_layer_finalization_hint(typed_finalization_hint)?;
         let typed_vk = ZkSyncRecursionLayerVerificationKey::from_inner(
-            recursive_circuit_type as u8,
+            circuit.numeric_circuit_type(),
             vk.clone(),
         );
         source.set_recursion_layer_vk(typed_vk)?;
@@ -268,46 +454,14 @@ pub fn generate_recursive_layer_vks_and_proofs(
 
         assert!(is_valid);
 
-        let proof = ZkSyncRecursionLayerProof::from_inner(recursive_circuit_type as u8, proof);
+        let proof = ZkSyncRecursionLayerProof::from_inner(circuit.numeric_circuit_type(), proof);
         source.set_recursion_layer_leaf_padding_proof(proof)?;
     }
 
     println!("Computing node vk");
 
     {
-        use crate::zkevm_circuits::recursion::node_layer::input::*;
-        let input = RecursionNodeInput::placeholder_witness();
-        let vk = source.get_recursion_layer_vk(
-            ZkSyncRecursionLayerStorageType::LeafLayerCircuitForMainVM as u8,
-        )?;
-
-        // the only thing to setup here is to have proper number of split points
-        use crate::boojum::gadgets::queue::QueueTailState;
-        let split_points = vec![QueueTailState::<GoldilocksField, FULL_SPONGE_QUEUE_STATE_WIDTH>::placeholder_witness(); RECURSION_ARITY-1];
-        let witness = RecursionNodeInstanceWitness {
-            input,
-            vk_witness: vk.clone().into_inner(),
-            split_points: split_points.into(),
-            proof_witnesses: VecDeque::new(),
-        };
-
-        use crate::zkevm_circuits::recursion::node_layer::NodeLayerRecursionConfig;
-        use circuit_definitions::circuit_definitions::recursion_layer::node_layer::ZkSyncNodeLayerRecursiveCircuit;
-        let config = NodeLayerRecursionConfig {
-            proof_config: recursion_layer_proof_config(),
-            vk_fixed_parameters: vk.into_inner().fixed_parameters,
-            leaf_layer_capacity: RECURSION_ARITY,
-            node_layer_capacity: RECURSION_ARITY,
-            _marker: std::marker::PhantomData,
-        };
-        let circuit = ZkSyncNodeLayerRecursiveCircuit {
-            witness: witness,
-            config: config,
-            transcript_params: (),
-            _marker: std::marker::PhantomData,
-        };
-
-        let circuit = ZkSyncRecursiveLayerCircuit::NodeLayerCircuit(circuit);
+        let circuit = get_node_circuit(source)?;
 
         let (setup_base, setup, vk, setup_tree, vars_hint, wits_hint, finalization_hint) =
             create_recursive_layer_setup_data(
@@ -352,34 +506,7 @@ pub fn generate_recursive_layer_vks_and_proofs(
     println!("Computing scheduler vk");
 
     {
-        use crate::zkevm_circuits::scheduler::SchedulerConfig;
-        use circuit_definitions::circuit_definitions::recursion_layer::scheduler::SchedulerCircuit;
-
-        let node_vk = source.get_recursion_layer_node_vk()?.into_inner();
-
-        let config = SchedulerConfig {
-            proof_config: recursion_layer_proof_config(),
-            vk_fixed_parameters: node_vk.fixed_parameters.clone(),
-            capacity: SCHEDULER_CAPACITY,
-            _marker: std::marker::PhantomData,
-        };
-
-        use crate::zkevm_circuits::scheduler::input::SchedulerCircuitInstanceWitness;
-        let mut scheduler_witness = SchedulerCircuitInstanceWitness::placeholder();
-        // the only thing we need to setup here is a VK
-        scheduler_witness.node_layer_vk_witness = node_vk;
-
-        let scheduler_circuit = SchedulerCircuit {
-            witness: scheduler_witness,
-            config,
-            transcript_params: (),
-            eip4844_proof_config: None,
-            eip4844_vk_fixed_parameters: None,
-            eip4844_vk: None,
-            _marker: std::marker::PhantomData,
-        };
-
-        let scheduler_circuit = ZkSyncRecursiveLayerCircuit::SchedulerCircuit(scheduler_circuit);
+        let scheduler_circuit = get_scheduler_circuit(source)?;
 
         let (_setup_base, _setup, vk, _setup_tree, _vars_hint, _wits_hint, finalization_hint) =
             create_recursive_layer_setup_data(


### PR DESCRIPTION
# What ❔

* Added new method - generate_circuit_setup_data - to generate setup data to the circuit.
* Created helper methods (get_all_recursive_circuits, get_leaf_circuits, get_node_circuits) - that will be later used in other tests and files.

## Why ❔

* This way, the logic of setup data generation can be fully in this crate (rather than split between here and zksync-era's prover crate).
