### PR TITLE
Small updates for 4844 circuit

### DIFF
--- a/src/tests/complex_tests/mod.rs
+++ b/src/tests/complex_tests/mod.rs
@@ -1000,7 +1000,7 @@ fn run_and_try_create_witness_inner(
         let mut eip4844_vk = None;
         for blob in blobs {
             let (blob_arr, linear_hash, versioned_hash, output_hash) =
-                generate_eip4844_witness::<GoldilocksField>(blob);
+                generate_eip4844_witness::<GoldilocksField>(blob, "src/kzg/trusted_setup.json");
             use crate::zkevm_circuits::eip_4844::input::BlobChunkWitness;
             use crate::zkevm_circuits::eip_4844::input::EIP4844CircuitInstanceWitness;
             use crate::zkevm_circuits::eip_4844::input::EIP4844InputOutputWitness;

--- a/src/tests/simple_tests/eip4844.rs
+++ b/src/tests/simple_tests/eip4844.rs
@@ -1,12 +1,11 @@
 use super::*;
 use crate::tests::eip4844_test_circuit;
 use crate::zkevm_circuits::eip_4844::input::*;
+use circuit_definitions::EIP4844_CYCLE_LIMIT;
 use crossbeam::atomic::AtomicCell;
 use rand::Rng;
 use std::collections::VecDeque;
 use std::sync::Arc;
-
-const EIP4844_CYCLE_LIMIT: usize = 4096;
 
 #[test]
 fn test_eip4844() {
@@ -15,7 +14,7 @@ fn test_eip4844() {
         .for_each(|byte| *byte = rand::thread_rng().gen());
 
     let (blob_arr, linear_hash, versioned_hash, output_hash) =
-        generate_eip4844_witness::<GoldilocksField>(blob);
+        generate_eip4844_witness::<GoldilocksField>(blob, "src/kzg/trusted_setup.json");
     let blob = blob_arr
         .iter()
         .map(|el| BlobChunkWitness { inner: *el })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -170,7 +170,7 @@ use snark_wrapper::franklin_crypto::bellman::PrimeField;
 
 /// Generates eip4844 witness for a given blob and using a trusted setup from a given json path.
 /// Returns blob array, linear hash, versioned hash and output hash.
-/// Blob must have exact lenght of 31 * 4096
+/// Blob must have exact length of 31 * 4096
 // Example trusted setup path is in "src/kzg/trusted_setup.json".
 pub fn generate_eip4844_witness<F: SmallField>(
     blob: Vec<u8>,


### PR DESCRIPTION
# What ❔

* Enforce that witness is generated only for blobs of a given side
*  pass trusted setup path as a parameter
* added synthesis function that is used for GPU vector preparation.

## Why ❔

* Small changes to prepare 4844 for general use.
