### PR TITLE
Add support for generating circuits and witnesses for eip4844

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -303,12 +303,13 @@ pub fn generate_eip4844_witness<F: SmallField>(
 
 pub fn generate_eip4844_circuit_and_witness(
     blob: Vec<u8>,
+    trusted_setup_path: &str,
 ) -> (
     EIP4844Circuit<GoldilocksField, ZkSyncDefaultRoundFunction>,
     EIP4844CircuitInstanceWitness<GoldilocksField>,
 ) {
     let (blob_arr, linear_hash, versioned_hash, output_hash) =
-        generate_eip4844_witness::<GoldilocksField>(blob);
+        generate_eip4844_witness::<GoldilocksField>(blob, trusted_setup_path);
     let blob = blob_arr
         .iter()
         .map(|el| BlobChunkWitness { inner: *el })


### PR DESCRIPTION
# What ❔

Enables prover subsystems to get circuit and witness for eip4844.

## Why ❔

Needed as part of eip4844 integration.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
