### PR TITLE
Bugfix in sort_storage_access

### DIFF
--- a/src/witness/sort_storage_access.rs
+++ b/src/witness/sort_storage_access.rs
@@ -30,7 +30,7 @@ pub fn sort_storage_access_queries<'a, L: LogQueryLike, I: IntoIterator<Item = &
         .collect();
 
     sorted_storage_queries_with_extra_timestamp.par_sort_by(|a, b| {
-        match a.raw_query.shard_id().cmp(&a.raw_query.shard_id()) {
+        match a.raw_query.shard_id().cmp(&b.raw_query.shard_id()) {
             Ordering::Equal => match a.raw_query.address().cmp(&b.raw_query.address()) {
                 Ordering::Equal => match a.raw_query.key().cmp(&b.raw_query.key()) {
                     Ordering::Equal => a.extended_timestamp.cmp(&b.extended_timestamp),
@@ -75,33 +75,22 @@ pub fn sort_storage_access_queries<'a, L: LogQueryLike, I: IntoIterator<Item = &
                     "invalid for query {:?}",
                     el
                 );
-                // first read potentially
+
                 if el.raw_query.rw_flag() == false {
                     current_element_history.did_read_at_depth_zero = true;
+                } else {
+                    assert!(el.raw_query.rollback() == false);
+                    // note: We apply updates few lines later
                 }
+
+                current_element_history.initial_value = Some(el.raw_query.read_value());
+                current_element_history.current_value = Some(el.raw_query.read_value());
             } else {
                 // explicit read at zero
                 if el.raw_query.rw_flag() == false
                     && current_element_history.changes_stack.is_empty()
                 {
                     current_element_history.did_read_at_depth_zero = true;
-                }
-            }
-
-            if current_element_history.current_value.is_none() {
-                assert!(
-                    current_element_history.initial_value.is_none(),
-                    "invalid for query {:?}",
-                    el
-                );
-                if el.raw_query.rw_flag() == false {
-                    current_element_history.initial_value = Some(el.raw_query.read_value());
-                    current_element_history.current_value = Some(el.raw_query.read_value());
-                } else {
-                    assert!(el.raw_query.rollback() == false);
-                    current_element_history.initial_value = Some(el.raw_query.read_value());
-                    current_element_history.current_value = Some(el.raw_query.read_value());
-                    // note: We apply updates few lines later
                 }
             }
 


### PR DESCRIPTION
Optimize redundant code and fix a bug

What ❔
Fix a bug in sort_storage_access_queries and simplified method implementation

Why ❔
There is a bug in the current method implementation. When sorting the sorted_storage_queries_with_extra_timestamp, the shard_id of a and b should be compared, but the current comparison is the shard_id of a and a self.

The conditional judgment current_element_history.current_value.is_none() appears twice and can be merged into one.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
