### PR TITLE
feat: Added circuit_sequencer_api to 1.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ name = "geometry_config_generator"
 path = "src/geometry_config_generator/main.rs"
 
 [dependencies]
+circuit_sequencer_api = {path = "./circuit_sequencer_api"}
+
 # zk_evm = {path = "../zk_evm"}
 # sync_vm = {path = "../sync_vm", features = ["external_testing"]}
 # zkevm-assembly = {path = "../zkEVM-assembly"}

--- a/circuit_sequencer_api/.gitignore
+++ b/circuit_sequencer_api/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/circuit_sequencer_api/Cargo.toml
+++ b/circuit_sequencer_api/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "circuit_sequencer_api"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+zk_evm = {git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.3.3"}
+bellman = { package = "bellman_ce", git = "https://github.com/matter-labs/bellman", branch = "dev" }
+
+
+derivative = "*"
+serde = {version = "1", features = ["derive"]}
+rayon = "*"
+
+
+[features]
+default = []

--- a/circuit_sequencer_api/README.md
+++ b/circuit_sequencer_api/README.md
@@ -1,0 +1,3 @@
+# circuit sequencer api
+
+Crate that can be used directly by the sequencer, without all the proving details.

--- a/circuit_sequencer_api/src/lib.rs
+++ b/circuit_sequencer_api/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod proof;
+pub mod sort_storage_access;
+
+pub const INITIAL_MONOTONIC_CYCLE_COUNTER: u32 = 1024;

--- a/circuit_sequencer_api/src/proof.rs
+++ b/circuit_sequencer_api/src/proof.rs
@@ -1,0 +1,25 @@
+use bellman::{
+    bn256::Bn256,
+    plonk::better_better_cs::{
+        cs::{Circuit, Width4MainGateWithDNext},
+        proof::Proof,
+    },
+};
+
+// Wrapper for the final scheduler proof.
+// We use generic circuit here, as this is used only for serializing & deserializing in sequencer.
+pub type FinalProof = Proof<Bn256, GenericCircuit>;
+
+#[derive(Clone)]
+pub struct GenericCircuit {}
+
+impl Circuit<Bn256> for GenericCircuit {
+    type MainGate = Width4MainGateWithDNext;
+
+    fn synthesize<CS: bellman::plonk::better_better_cs::cs::ConstraintSystem<Bn256>>(
+        &self,
+        _: &mut CS,
+    ) -> Result<(), bellman::SynthesisError> {
+        Ok(())
+    }
+}

--- a/circuit_sequencer_api/src/sort_storage_access.rs
+++ b/circuit_sequencer_api/src/sort_storage_access.rs
@@ -1,12 +1,11 @@
-use crate::encodings::log_query::*;
-use crate::ethereum_types::H160;
-use crate::ethereum_types::U256;
 use derivative::Derivative;
 use rayon::prelude::*;
 use std::cmp::Ordering;
 use std::iter::IntoIterator;
-use zk_evm::aux_structures::LogQuery;
-use zk_evm::aux_structures::Timestamp;
+use zk_evm::{
+    aux_structures::{LogQuery, Timestamp},
+    ethereum_types::{H160, U256},
+};
 
 #[derive(Derivative)]
 #[derivative(Default(bound = ""), Debug)]
@@ -126,7 +125,7 @@ pub fn sort_storage_access_queries<'a, L: LogQueryLike, I: IntoIterator<Item = &
             break;
         }
 
-        let candidate = it.peek().unwrap().clone();
+        let candidate = (*it.peek().unwrap()).clone();
 
         let subit = it.clone().take_while(|el| {
             el.raw_query.shard_id() == candidate.raw_query.shard_id()
@@ -242,8 +241,6 @@ pub fn sort_storage_access_queries<'a, L: LogQueryLike, I: IntoIterator<Item = &
                 }
             }
         }
-
-        use zk_evm::aux_structures::Timestamp;
 
         if current_element_history.did_read_at_depth_zero == false
             && current_element_history.changes_stack.is_empty()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub mod toolset;
 
 pub mod abstract_zksync_circuit;
 
-pub const INITIAL_MONOTONIC_CYCLE_COUNTER: u32 = 1024;
+pub use circuit_sequencer_api::INITIAL_MONOTONIC_CYCLE_COUNTER;
 
 // #[cfg(test)]
 pub(crate) mod tests;

--- a/src/witness/mod.rs
+++ b/src/witness/mod.rs
@@ -7,7 +7,7 @@ pub mod individual_circuits;
 pub mod oracle;
 pub mod postprocessing;
 pub mod recursive_aggregation;
-pub mod sort_storage_access;
+pub use circuit_sequencer_api::sort_storage_access;
 pub mod tracer;
 pub mod tree;
 pub mod utils;


### PR DESCRIPTION
# What ❔

* Added circuit_sequencer api to v1.3.3  (with full backwards compatibility)

## Why ❔

* To improve compilation times, and clearly match which functions can be used by sequencer.
