### PR TITLE
fix: Fixing a bug in sort_storage_access_queries

### DIFF
--- a/circuit_sequencer_api/src/sort_storage_access.rs
+++ b/circuit_sequencer_api/src/sort_storage_access.rs
@@ -29,7 +29,7 @@ pub fn sort_storage_access_queries<'a, L: LogQueryLike, I: IntoIterator<Item = &
         .collect();
 
     sorted_storage_queries_with_extra_timestamp.par_sort_by(|a, b| {
-        match a.raw_query.shard_id().cmp(&a.raw_query.shard_id()) {
+        match a.raw_query.shard_id().cmp(&b.raw_query.shard_id()) {
             Ordering::Equal => match a.raw_query.address().cmp(&b.raw_query.address()) {
                 Ordering::Equal => match a.raw_query.key().cmp(&b.raw_query.key()) {
                     Ordering::Equal => a.extended_timestamp.cmp(&b.extended_timestamp),

--- a/src/external_calls.rs
+++ b/src/external_calls.rs
@@ -69,7 +69,7 @@ pub fn run<
 >(
     caller: Address,                 // for real block must be zero
     entry_point_address: Address,    // for real block must be the bootloader
-    entry_point_code: Vec<[u8; 32]>, // for read lobkc must be a bootloader code
+    entry_point_code: Vec<[u8; 32]>, // for read block must be a bootloader code
     initial_heap_content: Vec<u8>,   // bootloader starts with non-deterministic heap
     zk_porter_is_available: bool,
     default_aa_code_hash: U256,


### PR DESCRIPTION
# What ❔

Fix a bug in sort_storage_access_queries and simplified method implementation.

PS: This is an old pr, i recently merged the latest v1.4.1 branch.

## Why ❔

There is a bug in the current method implementation. When sorting the sorted_storage_queries_with_extra_timestamp, the shard_id of a and b should be compared, but the current comparison is the shard_id of a and a self.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
