### PR TITLE
Improving compilation speed by avoiding generics - moving to branch 1.5.0

### DIFF
--- a/circuit_definitions/src/circuit_definitions/base_layer/code_decommitter.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/code_decommitter.rs
@@ -3,28 +3,19 @@ use derivative::*;
 use super::*;
 use crate::boojum::cs::traits::circuit::CircuitBuilder;
 
+type F = GoldilocksField;
+type R = Poseidon2Goldilocks;
+
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Copy, Debug, Default(bound = ""))]
-pub struct CodeDecommitterInstanceSynthesisFunction<
-    F: SmallField,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> {
+pub struct CodeDecommitterInstanceSynthesisFunction {
     _marker: std::marker::PhantomData<(F, R)>,
 }
 
 use zkevm_circuits::code_unpacker_sha256::input::*;
 use zkevm_circuits::code_unpacker_sha256::unpack_code_into_memory_entry_point;
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > CircuitBuilder<F> for CodeDecommitterInstanceSynthesisFunction<F, R>
+impl CircuitBuilder<F> for CodeDecommitterInstanceSynthesisFunction
 where
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <DecommitQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -106,13 +97,7 @@ where
     }
 }
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncUniformSynthesisFunction<F> for CodeDecommitterInstanceSynthesisFunction<F, R>
+impl ZkSyncUniformSynthesisFunction<F> for CodeDecommitterInstanceSynthesisFunction
 where
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <DecommitQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,

--- a/circuit_definitions/src/circuit_definitions/base_layer/ecrecover.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/ecrecover.rs
@@ -3,31 +3,21 @@ use derivative::*;
 use super::*;
 use crate::boojum::cs::traits::circuit::CircuitBuilder;
 
+type F = GoldilocksField;
+type R = Poseidon2Goldilocks;
+
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Copy, Debug, Default(bound = ""))]
-pub struct ECRecoverFunctionInstanceSynthesisFunction<
-    F: SmallField,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> {
+pub struct ECRecoverFunctionInstanceSynthesisFunction {
     _marker: std::marker::PhantomData<(F, R)>,
 }
 
 use zkevm_circuits::ecrecover::input::*;
 use zkevm_circuits::ecrecover::{
-    decomp_table::*, ecrecover_function_entry_point, naf_abs_div2_table::*,
-    secp256k1::fixed_base_mul_table::*,
+    ecrecover_function_entry_point, secp256k1::fixed_base_mul_table::*,
 };
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > CircuitBuilder<F> for ECRecoverFunctionInstanceSynthesisFunction<F, R>
+impl CircuitBuilder<F> for ECRecoverFunctionInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -124,13 +114,7 @@ where
     }
 }
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncUniformSynthesisFunction<F> for ECRecoverFunctionInstanceSynthesisFunction<F, R>
+impl ZkSyncUniformSynthesisFunction<F> for ECRecoverFunctionInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,

--- a/circuit_definitions/src/circuit_definitions/base_layer/events_sort_dedup.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/events_sort_dedup.rs
@@ -3,28 +3,19 @@ use derivative::*;
 use super::*;
 use crate::boojum::cs::traits::circuit::CircuitBuilder;
 
+type F = GoldilocksField;
+type R = Poseidon2Goldilocks;
+
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Copy, Debug, Default(bound = ""))]
-pub struct EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction<
-    F: SmallField,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> {
+pub struct EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction {
     _marker: std::marker::PhantomData<(F, R)>,
 }
 
 use zkevm_circuits::log_sorter::input::*;
 use zkevm_circuits::log_sorter::sort_and_deduplicate_events_entry_point;
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > CircuitBuilder<F> for EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction<F, R>
+impl CircuitBuilder<F> for EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction
 where
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <DecommitQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -107,14 +98,7 @@ where
     }
 }
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncUniformSynthesisFunction<F>
-    for EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction<F, R>
+impl ZkSyncUniformSynthesisFunction<F> for EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction
 where
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <DecommitQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,

--- a/circuit_definitions/src/circuit_definitions/base_layer/keccak256_round_function.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/keccak256_round_function.rs
@@ -3,28 +3,19 @@ use derivative::*;
 use super::*;
 use crate::boojum::cs::traits::circuit::CircuitBuilder;
 
+type F = GoldilocksField;
+type R = Poseidon2Goldilocks;
+
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Copy, Debug, Default(bound = ""))]
-pub struct Keccak256RoundFunctionInstanceSynthesisFunction<
-    F: SmallField,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> {
+pub struct Keccak256RoundFunctionInstanceSynthesisFunction {
     _marker: std::marker::PhantomData<(F, R)>,
 }
 
 use zkevm_circuits::keccak256_round_function::input::Keccak256RoundFunctionCircuitInstanceWitness;
 use zkevm_circuits::keccak256_round_function::keccak256_round_function_entry_point;
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > CircuitBuilder<F> for Keccak256RoundFunctionInstanceSynthesisFunction<F, R>
+impl CircuitBuilder<F> for Keccak256RoundFunctionInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -114,13 +105,7 @@ where
     }
 }
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncUniformSynthesisFunction<F> for Keccak256RoundFunctionInstanceSynthesisFunction<F, R>
+impl ZkSyncUniformSynthesisFunction<F> for Keccak256RoundFunctionInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,

--- a/circuit_definitions/src/circuit_definitions/base_layer/linear_hasher.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/linear_hasher.rs
@@ -3,28 +3,19 @@ use derivative::*;
 use super::*;
 use crate::boojum::cs::traits::circuit::CircuitBuilder;
 
+type F = GoldilocksField;
+type R = Poseidon2Goldilocks;
+
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Copy, Debug, Default(bound = ""))]
-pub struct LinearHasherInstanceSynthesisFunction<
-    F: SmallField,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> {
+pub struct LinearHasherInstanceSynthesisFunction {
     _marker: std::marker::PhantomData<(F, R)>,
 }
 
 use zkevm_circuits::linear_hasher::input::LinearHasherCircuitInstanceWitness;
 use zkevm_circuits::linear_hasher::linear_hasher_entry_point;
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > CircuitBuilder<F> for LinearHasherInstanceSynthesisFunction<F, R>
+impl CircuitBuilder<F> for LinearHasherInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -110,13 +101,7 @@ where
     }
 }
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncUniformSynthesisFunction<F> for LinearHasherInstanceSynthesisFunction<F, R>
+impl ZkSyncUniformSynthesisFunction<F> for LinearHasherInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,

--- a/circuit_definitions/src/circuit_definitions/base_layer/log_demux.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/log_demux.rs
@@ -1,30 +1,29 @@
 use derivative::*;
+use snark_wrapper::boojum::cs::implementations::transcript::GoldilocksPoisedon2Transcript;
+use snark_wrapper::boojum::gadgets::recursion::recursive_transcript::CircuitAlgebraicSpongeBasedTranscript;
+use snark_wrapper::boojum::gadgets::recursion::recursive_tree_hasher::CircuitGoldilocksPoseidon2Sponge;
 
 use super::*;
 use crate::boojum::cs::traits::circuit::CircuitBuilder;
 
+type F = GoldilocksField;
+type TR = GoldilocksPoisedon2Transcript;
+type R = Poseidon2Goldilocks;
+type CTR = CircuitAlgebraicSpongeBasedTranscript<GoldilocksField, 8, 12, 4, R>;
+type EXT = GoldilocksExt2;
+type H = GoldilocksPoseidon2Sponge<AbsorptionModeOverwrite>;
+type RH = CircuitGoldilocksPoseidon2Sponge;
+
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Copy, Debug, Default(bound = ""))]
-pub struct LogDemuxInstanceSynthesisFunction<
-    F: SmallField,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> {
+pub struct LogDemuxInstanceSynthesisFunction {
     _marker: std::marker::PhantomData<(F, R)>,
 }
 
 use zkevm_circuits::demux_log_queue::demultiplex_storage_logs_enty_point;
 use zkevm_circuits::demux_log_queue::input::LogDemuxerCircuitInstanceWitness;
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > CircuitBuilder<F> for LogDemuxInstanceSynthesisFunction<F, R>
+impl CircuitBuilder<F> for LogDemuxInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -107,13 +106,7 @@ where
     }
 }
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncUniformSynthesisFunction<F> for LogDemuxInstanceSynthesisFunction<F, R>
+impl ZkSyncUniformSynthesisFunction<F> for LogDemuxInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,

--- a/circuit_definitions/src/circuit_definitions/base_layer/mod.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/mod.rs
@@ -47,32 +47,36 @@ pub use self::vm_main::VmMainInstanceSynthesisFunction;
 // Type definitions for circuits, so one can easily form circuits with witness, and their definition
 // will take care of particular synthesis function. There is already an implementation of Circuit<F> for ZkSyncUniformCircuitInstance,
 // so as soon as the structure is instantiated it is ready for proving
-pub type VMMainCircuit<F, W, R> =
-    ZkSyncUniformCircuitInstance<F, VmMainInstanceSynthesisFunction<F, W, R>>;
-pub type CodeDecommittsSorterCircuit<F, R> =
-    ZkSyncUniformCircuitInstance<F, CodeDecommittmentsSorterSynthesisFunction<F, R>>;
-pub type CodeDecommitterCircuit<F, R> =
-    ZkSyncUniformCircuitInstance<F, CodeDecommitterInstanceSynthesisFunction<F, R>>;
-pub type LogDemuxerCircuit<F, R> =
-    ZkSyncUniformCircuitInstance<F, LogDemuxInstanceSynthesisFunction<F, R>>;
-pub type Keccak256RoundFunctionCircuit<F, R> =
-    ZkSyncUniformCircuitInstance<F, Keccak256RoundFunctionInstanceSynthesisFunction<F, R>>;
-pub type Sha256RoundFunctionCircuit<F, R> =
-    ZkSyncUniformCircuitInstance<F, Sha256RoundFunctionInstanceSynthesisFunction<F, R>>;
-pub type ECRecoverFunctionCircuit<F, R> =
-    ZkSyncUniformCircuitInstance<F, ECRecoverFunctionInstanceSynthesisFunction<F, R>>;
-pub type RAMPermutationCircuit<F, R> =
-    ZkSyncUniformCircuitInstance<F, RAMPermutationInstanceSynthesisFunction<F, R>>;
-pub type StorageSorterCircuit<F, R> =
-    ZkSyncUniformCircuitInstance<F, StorageSortAndDedupInstanceSynthesisFunction<F, R>>;
-pub type StorageApplicationCircuit<F, R> =
-    ZkSyncUniformCircuitInstance<F, StorageApplicationInstanceSynthesisFunction<F, R>>;
-pub type EventsSorterCircuit<F, R> =
-    ZkSyncUniformCircuitInstance<F, EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction<F, R>>;
-pub type L1MessagesSorterCircuit<F, R> =
-    ZkSyncUniformCircuitInstance<F, EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction<F, R>>;
-pub type L1MessagesHasherCircuit<F, R> =
-    ZkSyncUniformCircuitInstance<F, LinearHasherInstanceSynthesisFunction<F, R>>;
+pub type VMMainCircuit =
+    ZkSyncUniformCircuitInstance<GoldilocksField, VmMainInstanceSynthesisFunction>;
+pub type CodeDecommittsSorterCircuit =
+    ZkSyncUniformCircuitInstance<GoldilocksField, CodeDecommittmentsSorterSynthesisFunction>;
+pub type CodeDecommitterCircuit =
+    ZkSyncUniformCircuitInstance<GoldilocksField, CodeDecommitterInstanceSynthesisFunction>;
+pub type LogDemuxerCircuit =
+    ZkSyncUniformCircuitInstance<GoldilocksField, LogDemuxInstanceSynthesisFunction>;
+pub type Keccak256RoundFunctionCircuit =
+    ZkSyncUniformCircuitInstance<GoldilocksField, Keccak256RoundFunctionInstanceSynthesisFunction>;
+pub type Sha256RoundFunctionCircuit =
+    ZkSyncUniformCircuitInstance<GoldilocksField, Sha256RoundFunctionInstanceSynthesisFunction>;
+pub type ECRecoverFunctionCircuit =
+    ZkSyncUniformCircuitInstance<GoldilocksField, ECRecoverFunctionInstanceSynthesisFunction>;
+pub type RAMPermutationCircuit =
+    ZkSyncUniformCircuitInstance<GoldilocksField, RAMPermutationInstanceSynthesisFunction>;
+pub type StorageSorterCircuit =
+    ZkSyncUniformCircuitInstance<GoldilocksField, StorageSortAndDedupInstanceSynthesisFunction>;
+pub type StorageApplicationCircuit =
+    ZkSyncUniformCircuitInstance<GoldilocksField, StorageApplicationInstanceSynthesisFunction>;
+pub type EventsSorterCircuit = ZkSyncUniformCircuitInstance<
+    GoldilocksField,
+    EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction,
+>;
+pub type L1MessagesSorterCircuit = ZkSyncUniformCircuitInstance<
+    GoldilocksField,
+    EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction,
+>;
+pub type L1MessagesHasherCircuit =
+    ZkSyncUniformCircuitInstance<GoldilocksField, LinearHasherInstanceSynthesisFunction>;
 
 #[derive(derivative::Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone(bound = ""), Debug)]
@@ -202,17 +206,14 @@ impl<T: Clone + std::fmt::Debug + serde::Serialize + serde::de::DeserializeOwned
     }
 }
 
+type F = GoldilocksField;
+type R = Poseidon2Goldilocks;
+
 #[derive(derivative::Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone(bound = ""))]
 #[serde(bound = "")]
-pub enum ZkSyncBaseLayerCircuit<
-    F: SmallField,
-    W: WitnessOracle<F>,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> where
+pub enum ZkSyncBaseLayerCircuit
+where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <DecommitQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -221,29 +222,22 @@ pub enum ZkSyncBaseLayerCircuit<
     [(); <ExecutionContextRecord<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <TimestampedStorageLogRecord<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
 {
-    MainVM(VMMainCircuit<F, W, R>),
-    CodeDecommittmentsSorter(CodeDecommittsSorterCircuit<F, R>),
-    CodeDecommitter(CodeDecommitterCircuit<F, R>),
-    LogDemuxer(LogDemuxerCircuit<F, R>),
-    KeccakRoundFunction(Keccak256RoundFunctionCircuit<F, R>),
-    Sha256RoundFunction(Sha256RoundFunctionCircuit<F, R>),
-    ECRecover(ECRecoverFunctionCircuit<F, R>),
-    RAMPermutation(RAMPermutationCircuit<F, R>),
-    StorageSorter(StorageSorterCircuit<F, R>),
-    StorageApplication(StorageApplicationCircuit<F, R>),
-    EventsSorter(EventsSorterCircuit<F, R>),
-    L1MessagesSorter(L1MessagesSorterCircuit<F, R>),
-    L1MessagesHasher(L1MessagesHasherCircuit<F, R>),
+    MainVM(VMMainCircuit),
+    CodeDecommittmentsSorter(CodeDecommittsSorterCircuit),
+    CodeDecommitter(CodeDecommitterCircuit),
+    LogDemuxer(LogDemuxerCircuit),
+    KeccakRoundFunction(Keccak256RoundFunctionCircuit),
+    Sha256RoundFunction(Sha256RoundFunctionCircuit),
+    ECRecover(ECRecoverFunctionCircuit),
+    RAMPermutation(RAMPermutationCircuit),
+    StorageSorter(StorageSorterCircuit),
+    StorageApplication(StorageApplicationCircuit),
+    EventsSorter(EventsSorterCircuit),
+    L1MessagesSorter(L1MessagesSorterCircuit),
+    L1MessagesHasher(L1MessagesHasherCircuit),
 }
 
-impl<
-        F: SmallField,
-        W: WitnessOracle<F>,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncBaseLayerCircuit<F, W, R>
+impl ZkSyncBaseLayerCircuit
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,

--- a/circuit_definitions/src/circuit_definitions/base_layer/ram_permutation.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/ram_permutation.rs
@@ -3,28 +3,19 @@ use derivative::*;
 use super::*;
 use crate::boojum::cs::traits::circuit::CircuitBuilder;
 
+type F = GoldilocksField;
+type R = Poseidon2Goldilocks;
+
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Copy, Debug, Default(bound = ""))]
-pub struct RAMPermutationInstanceSynthesisFunction<
-    F: SmallField,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> {
+pub struct RAMPermutationInstanceSynthesisFunction {
     _marker: std::marker::PhantomData<(F, R)>,
 }
 
 use zkevm_circuits::ram_permutation::input::*;
 use zkevm_circuits::ram_permutation::ram_permutation_entry_point;
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > CircuitBuilder<F> for RAMPermutationInstanceSynthesisFunction<F, R>
+impl CircuitBuilder<F> for RAMPermutationInstanceSynthesisFunction
 where
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <DecommitQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -107,13 +98,7 @@ where
     }
 }
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncUniformSynthesisFunction<F> for RAMPermutationInstanceSynthesisFunction<F, R>
+impl ZkSyncUniformSynthesisFunction<F> for RAMPermutationInstanceSynthesisFunction
 where
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <DecommitQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,

--- a/circuit_definitions/src/circuit_definitions/base_layer/sha256_round_function.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/sha256_round_function.rs
@@ -3,28 +3,19 @@ use derivative::*;
 use super::*;
 use crate::boojum::cs::traits::circuit::CircuitBuilder;
 
+type F = GoldilocksField;
+type R = Poseidon2Goldilocks;
+
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Copy, Debug, Default(bound = ""))]
-pub struct Sha256RoundFunctionInstanceSynthesisFunction<
-    F: SmallField,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> {
+pub struct Sha256RoundFunctionInstanceSynthesisFunction {
     _marker: std::marker::PhantomData<(F, R)>,
 }
 
 use zkevm_circuits::sha256_round_function::input::*;
 use zkevm_circuits::sha256_round_function::sha256_round_function_entry_point;
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > CircuitBuilder<F> for Sha256RoundFunctionInstanceSynthesisFunction<F, R>
+impl CircuitBuilder<F> for Sha256RoundFunctionInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -106,13 +97,7 @@ where
     }
 }
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncUniformSynthesisFunction<F> for Sha256RoundFunctionInstanceSynthesisFunction<F, R>
+impl ZkSyncUniformSynthesisFunction<F> for Sha256RoundFunctionInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,

--- a/circuit_definitions/src/circuit_definitions/base_layer/sort_code_decommits.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/sort_code_decommits.rs
@@ -3,28 +3,19 @@ use derivative::*;
 use super::*;
 use crate::boojum::cs::traits::circuit::CircuitBuilder;
 
+type F = GoldilocksField;
+type R = Poseidon2Goldilocks;
+
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Copy, Debug, Default(bound = ""))]
-pub struct CodeDecommittmentsSorterSynthesisFunction<
-    F: SmallField,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> {
+pub struct CodeDecommittmentsSorterSynthesisFunction {
     _marker: std::marker::PhantomData<(F, R)>,
 }
 
 use zkevm_circuits::sort_decommittment_requests::input::*;
 use zkevm_circuits::sort_decommittment_requests::sort_and_deduplicate_code_decommittments_entry_point;
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > CircuitBuilder<F> for CodeDecommittmentsSorterSynthesisFunction<F, R>
+impl CircuitBuilder<F> for CodeDecommittmentsSorterSynthesisFunction
 where
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <DecommitQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -107,13 +98,7 @@ where
     }
 }
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncUniformSynthesisFunction<F> for CodeDecommittmentsSorterSynthesisFunction<F, R>
+impl ZkSyncUniformSynthesisFunction<F> for CodeDecommittmentsSorterSynthesisFunction
 where
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <DecommitQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,

--- a/circuit_definitions/src/circuit_definitions/base_layer/storage_apply.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/storage_apply.rs
@@ -3,28 +3,19 @@ use derivative::*;
 use super::*;
 use crate::boojum::cs::traits::circuit::CircuitBuilder;
 
+type F = GoldilocksField;
+type R = Poseidon2Goldilocks;
+
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Copy, Debug, Default(bound = ""))]
-pub struct StorageApplicationInstanceSynthesisFunction<
-    F: SmallField,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> {
+pub struct StorageApplicationInstanceSynthesisFunction {
     _marker: std::marker::PhantomData<(F, R)>,
 }
 
 use zkevm_circuits::storage_application::input::StorageApplicationCircuitInstanceWitness;
 use zkevm_circuits::storage_application::storage_applicator_entry_point;
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > CircuitBuilder<F> for StorageApplicationInstanceSynthesisFunction<F, R>
+impl CircuitBuilder<F> for StorageApplicationInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -110,13 +101,7 @@ where
     }
 }
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncUniformSynthesisFunction<F> for StorageApplicationInstanceSynthesisFunction<F, R>
+impl ZkSyncUniformSynthesisFunction<F> for StorageApplicationInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,

--- a/circuit_definitions/src/circuit_definitions/base_layer/storage_sort_dedup.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/storage_sort_dedup.rs
@@ -3,28 +3,19 @@ use derivative::*;
 use super::*;
 use crate::boojum::cs::traits::circuit::CircuitBuilder;
 
+type F = GoldilocksField;
+type R = Poseidon2Goldilocks;
+
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Copy, Debug, Default(bound = ""))]
-pub struct StorageSortAndDedupInstanceSynthesisFunction<
-    F: SmallField,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> {
+pub struct StorageSortAndDedupInstanceSynthesisFunction {
     _marker: std::marker::PhantomData<(F, R)>,
 }
 
 use zkevm_circuits::storage_validity_by_grand_product::input::*;
 use zkevm_circuits::storage_validity_by_grand_product::sort_and_deduplicate_storage_access_entry_point;
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > CircuitBuilder<F> for StorageSortAndDedupInstanceSynthesisFunction<F, R>
+impl CircuitBuilder<F> for StorageSortAndDedupInstanceSynthesisFunction
 where
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <DecommitQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -108,13 +99,7 @@ where
     }
 }
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncUniformSynthesisFunction<F> for StorageSortAndDedupInstanceSynthesisFunction<F, R>
+impl ZkSyncUniformSynthesisFunction<F> for StorageSortAndDedupInstanceSynthesisFunction
 where
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <DecommitQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,

--- a/circuit_definitions/src/circuit_definitions/base_layer/vm_main.rs
+++ b/circuit_definitions/src/circuit_definitions/base_layer/vm_main.rs
@@ -1,33 +1,23 @@
 use derivative::*;
 
 use super::*;
+use crate::aux_definitions::witness_oracle::VmWitnessOracle;
 use crate::boojum::cs::traits::circuit::CircuitBuilder;
+
+type F = GoldilocksField;
+type R = Poseidon2Goldilocks;
 
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Copy, Debug, Default(bound = ""))]
 #[serde(bound = "")]
-pub struct VmMainInstanceSynthesisFunction<
-    F: SmallField,
-    W: WitnessOracle<F>,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> {
-    _marker: std::marker::PhantomData<(F, W, R)>,
+pub struct VmMainInstanceSynthesisFunction {
+    _marker: std::marker::PhantomData<(F, R)>,
 }
 
 use zkevm_circuits::fsm_input_output::circuit_inputs::main_vm::VmCircuitWitness;
 use zkevm_circuits::main_vm::main_vm_entry_point;
 
-impl<
-        F: SmallField,
-        W: WitnessOracle<F>,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > CircuitBuilder<F> for VmMainInstanceSynthesisFunction<F, W, R>
+impl CircuitBuilder<F> for VmMainInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -128,14 +118,7 @@ where
     }
 }
 
-impl<
-        F: SmallField,
-        W: WitnessOracle<F>,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncUniformSynthesisFunction<F> for VmMainInstanceSynthesisFunction<F, W, R>
+impl ZkSyncUniformSynthesisFunction<F> for VmMainInstanceSynthesisFunction
 where
     [(); <LogQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <MemoryQuery<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
@@ -144,7 +127,7 @@ where
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN + 1]:,
     [(); <ExecutionContextRecord<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
 {
-    type Witness = VmCircuitWitness<F, W>;
+    type Witness = VmCircuitWitness<F, VmWitnessOracle<F>>;
     type Config = usize;
     type RoundFunction = R;
 

--- a/circuit_definitions/src/circuit_definitions/eip4844/mod.rs
+++ b/circuit_definitions/src/circuit_definitions/eip4844/mod.rs
@@ -4,7 +4,9 @@ use crate::boojum::cs::cs_builder_reference::CsReferenceImplementationBuilder;
 use crate::boojum::cs::implementations::reference_cs::CSReferenceAssembly;
 use crate::boojum::cs::implementations::setup::FinalizationHintsForProver;
 use crate::boojum::dag::CircuitResolver;
+use crate::boojum::field::goldilocks::GoldilocksField;
 use crate::boojum::field::traits::field_like::PrimeFieldLikeVectorized;
+
 use derivative::*;
 
 use super::*;
@@ -19,31 +21,21 @@ use crate::circuit_definitions::base_layer::TARGET_CIRCUIT_TRACE_LENGTH;
 use crate::circuit_definitions::gates::*;
 use crate::circuit_definitions::traits::gate::GatePlacementStrategy;
 
-pub type EIP4844Circuit<F, R> =
-    ZkSyncUniformCircuitInstance<F, EIP4844InstanceSynthesisFunction<F, R>>;
+type F = GoldilocksField;
+type R = Poseidon2Goldilocks;
+
+pub type EIP4844Circuit = ZkSyncUniformCircuitInstance<F, EIP4844InstanceSynthesisFunction>;
 
 #[derive(Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone, Copy, Debug, Default(bound = ""))]
-pub struct EIP4844InstanceSynthesisFunction<
-    F: SmallField,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
-> {
+pub struct EIP4844InstanceSynthesisFunction {
     _marker: std::marker::PhantomData<(F, R)>,
 }
 
 use zkevm_circuits::eip_4844::eip_4844_entry_point;
 use zkevm_circuits::eip_4844::input::*;
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > CircuitBuilder<F> for EIP4844InstanceSynthesisFunction<F, R>
+impl CircuitBuilder<F> for EIP4844InstanceSynthesisFunction
 where
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN + 1]:,
@@ -117,13 +109,7 @@ where
     }
 }
 
-impl<
-        F: SmallField,
-        R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-            + AlgebraicRoundFunction<F, 8, 12, 4>
-            + serde::Serialize
-            + serde::de::DeserializeOwned,
-    > ZkSyncUniformSynthesisFunction<F> for EIP4844InstanceSynthesisFunction<F, R>
+impl ZkSyncUniformSynthesisFunction<F> for EIP4844InstanceSynthesisFunction
 where
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN]:,
     [(); <UInt256<F> as CSAllocatableExt<F>>::INTERNAL_STRUCT_LEN + 1]:,
@@ -167,8 +153,8 @@ where
     }
 }
 
-pub fn synthesis<F, P, R, CR>(
-    circuit: EIP4844Circuit<F, R>,
+pub fn synthesis<P, CR>(
+    circuit: EIP4844Circuit,
     hint: &FinalizationHintsForProver,
 ) -> CSReferenceAssembly<F, P, ProvingCSConfig>
 where

--- a/circuit_definitions/src/circuit_definitions/recursion_layer/leaf_layer.rs
+++ b/circuit_definitions/src/circuit_definitions/recursion_layer/leaf_layer.rs
@@ -118,7 +118,7 @@ where
         } = self;
 
         use crate::circuit_definitions::verifier_builder::dyn_recursive_verifier_builder_for_circuit_type;
-        let verifier_builder = dyn_recursive_verifier_builder_for_circuit_type::<F, EXT, CS, R>(
+        let verifier_builder = dyn_recursive_verifier_builder_for_circuit_type::<CS>(
             self.base_layer_circuit_type as u8,
         );
 

--- a/circuit_definitions/src/circuit_definitions/recursion_layer/scheduler.rs
+++ b/circuit_definitions/src/circuit_definitions/recursion_layer/scheduler.rs
@@ -9,7 +9,6 @@ use crate::boojum::gadgets::recursion::circuit_pow::*;
 use crate::boojum::gadgets::tables::*;
 use crate::circuit_definitions::base_layer::TARGET_CIRCUIT_TRACE_LENGTH;
 use crate::circuit_definitions::implementations::verifier::VerificationKeyCircuitGeometry;
-use crate::circuit_definitions::traits::circuit::ErasedBuilderForRecursiveVerifier;
 use crate::circuit_definitions::verifier_builder::EIP4844VerifierBuilder;
 use crate::ProofConfig;
 use zkevm_circuits::base_structures::recursion_query::RecursionQuery;
@@ -204,7 +203,7 @@ where
             NodeLayerCircuitBuilder::<POW>::dyn_recursive_verifier_builder::<EXT, CS>();
 
         let eip4844_verifier_builder = if eip4844_proof_config.is_some() {
-            Some(EIP4844VerifierBuilder::<F, ZkSyncDefaultRoundFunction>::dyn_recursive_verifier_builder())
+            Some(EIP4844VerifierBuilder::dyn_recursive_verifier_builder())
         } else {
             None
         };

--- a/circuit_definitions/src/circuit_definitions/verifier_builder.rs
+++ b/circuit_definitions/src/circuit_definitions/verifier_builder.rs
@@ -1,50 +1,46 @@
-use super::*;
+use snark_wrapper::boojum::field::goldilocks::{GoldilocksExt2, GoldilocksField};
 
-use crate::aux_definitions::witness_oracle::VmWitnessOracle;
+use super::*;
 
 use crate::boojum::cs::traits::circuit::CircuitBuilderProxy;
 use crate::circuit_definitions::base_layer::*;
 
 use crate::circuit_definitions::eip4844::EIP4844InstanceSynthesisFunction;
 
-pub type EIP4844VerifierBuilder<F, R> =
-    CircuitBuilderProxy<F, EIP4844InstanceSynthesisFunction<F, R>>;
+pub type EIP4844VerifierBuilder = CircuitBuilderProxy<F, EIP4844InstanceSynthesisFunction>;
 
-pub type VMMainCircuitVerifierBuilder<F, W, R> =
-    CircuitBuilderProxy<F, VmMainInstanceSynthesisFunction<F, W, R>>;
-pub type CodeDecommittsSorterVerifierBuilder<F, R> =
-    CircuitBuilderProxy<F, CodeDecommittmentsSorterSynthesisFunction<F, R>>;
-pub type CodeDecommitterVerifierBuilder<F, R> =
-    CircuitBuilderProxy<F, CodeDecommitterInstanceSynthesisFunction<F, R>>;
-pub type LogDemuxerVerifierBuilder<F, R> =
-    CircuitBuilderProxy<F, LogDemuxInstanceSynthesisFunction<F, R>>;
-pub type Keccak256RoundFunctionVerifierBuilder<F, R> =
-    CircuitBuilderProxy<F, Keccak256RoundFunctionInstanceSynthesisFunction<F, R>>;
-pub type Sha256RoundFunctionVerifierBuilder<F, R> =
-    CircuitBuilderProxy<F, Sha256RoundFunctionInstanceSynthesisFunction<F, R>>;
-pub type ECRecoverFunctionVerifierBuilder<F, R> =
-    CircuitBuilderProxy<F, ECRecoverFunctionInstanceSynthesisFunction<F, R>>;
-pub type RAMPermutationVerifierBuilder<F, R> =
-    CircuitBuilderProxy<F, RAMPermutationInstanceSynthesisFunction<F, R>>;
-pub type StorageSorterVerifierBuilder<F, R> =
-    CircuitBuilderProxy<F, StorageSortAndDedupInstanceSynthesisFunction<F, R>>;
-pub type StorageApplicationVerifierBuilder<F, R> =
-    CircuitBuilderProxy<F, StorageApplicationInstanceSynthesisFunction<F, R>>;
-pub type EventsSorterVerifierBuilder<F, R> =
-    CircuitBuilderProxy<F, EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction<F, R>>;
-pub type L1MessagesSorterVerifierBuilder<F, R> =
-    CircuitBuilderProxy<F, EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction<F, R>>;
-pub type L1MessagesHaherVerifierBuilder<F, R> =
-    CircuitBuilderProxy<F, LinearHasherInstanceSynthesisFunction<F, R>>;
+pub type VMMainCircuitVerifierBuilder =
+    CircuitBuilderProxy<GoldilocksField, VmMainInstanceSynthesisFunction>;
+pub type CodeDecommittsSorterVerifierBuilder =
+    CircuitBuilderProxy<GoldilocksField, CodeDecommittmentsSorterSynthesisFunction>;
+pub type CodeDecommitterVerifierBuilder =
+    CircuitBuilderProxy<GoldilocksField, CodeDecommitterInstanceSynthesisFunction>;
+pub type LogDemuxerVerifierBuilder =
+    CircuitBuilderProxy<GoldilocksField, LogDemuxInstanceSynthesisFunction>;
+pub type Keccak256RoundFunctionVerifierBuilder =
+    CircuitBuilderProxy<GoldilocksField, Keccak256RoundFunctionInstanceSynthesisFunction>;
+pub type Sha256RoundFunctionVerifierBuilder =
+    CircuitBuilderProxy<GoldilocksField, Sha256RoundFunctionInstanceSynthesisFunction>;
+pub type ECRecoverFunctionVerifierBuilder =
+    CircuitBuilderProxy<GoldilocksField, ECRecoverFunctionInstanceSynthesisFunction>;
+pub type RAMPermutationVerifierBuilder =
+    CircuitBuilderProxy<GoldilocksField, RAMPermutationInstanceSynthesisFunction>;
+pub type StorageSorterVerifierBuilder =
+    CircuitBuilderProxy<GoldilocksField, StorageSortAndDedupInstanceSynthesisFunction>;
+pub type StorageApplicationVerifierBuilder =
+    CircuitBuilderProxy<GoldilocksField, StorageApplicationInstanceSynthesisFunction>;
+pub type EventsSorterVerifierBuilder =
+    CircuitBuilderProxy<GoldilocksField, EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction>;
+pub type L1MessagesSorterVerifierBuilder =
+    CircuitBuilderProxy<GoldilocksField, EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction>;
+pub type L1MessagesHaherVerifierBuilder =
+    CircuitBuilderProxy<GoldilocksField, LinearHasherInstanceSynthesisFunction>;
 
-pub fn dyn_verifier_builder_for_circuit_type<
-    F: SmallField,
-    EXT: FieldExtension<2, BaseField = F>,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
->(
+type F = GoldilocksField;
+type EXT = GoldilocksExt2;
+type R = Poseidon2Goldilocks;
+
+pub fn dyn_verifier_builder_for_circuit_type(
     circuit_type: u8,
 ) -> Box<dyn crate::boojum::cs::traits::circuit::ErasedBuilderForVerifier<F, EXT>>
 where
@@ -60,43 +56,43 @@ where
 
     match circuit_type {
         i if i == BaseLayerCircuitType::VM as u8 => {
-            VMMainCircuitVerifierBuilder::<F, VmWitnessOracle<F>, R>::dyn_verifier_builder()
+            VMMainCircuitVerifierBuilder::dyn_verifier_builder()
         }
         i if i == BaseLayerCircuitType::DecommitmentsFilter as u8 => {
-            CodeDecommittsSorterVerifierBuilder::<F, R>::dyn_verifier_builder()
+            CodeDecommittsSorterVerifierBuilder::dyn_verifier_builder()
         }
         i if i == BaseLayerCircuitType::Decommiter as u8 => {
-            CodeDecommitterVerifierBuilder::<F, R>::dyn_verifier_builder()
+            CodeDecommitterVerifierBuilder::dyn_verifier_builder()
         }
         i if i == BaseLayerCircuitType::LogDemultiplexer as u8 => {
-            LogDemuxerVerifierBuilder::<F, R>::dyn_verifier_builder()
+            LogDemuxerVerifierBuilder::dyn_verifier_builder()
         }
         i if i == BaseLayerCircuitType::KeccakPrecompile as u8 => {
-            Keccak256RoundFunctionVerifierBuilder::<F, R>::dyn_verifier_builder()
+            Keccak256RoundFunctionVerifierBuilder::dyn_verifier_builder()
         }
         i if i == BaseLayerCircuitType::Sha256Precompile as u8 => {
-            Sha256RoundFunctionVerifierBuilder::<F, R>::dyn_verifier_builder()
+            Sha256RoundFunctionVerifierBuilder::dyn_verifier_builder()
         }
         i if i == BaseLayerCircuitType::EcrecoverPrecompile as u8 => {
-            ECRecoverFunctionVerifierBuilder::<F, R>::dyn_verifier_builder()
+            ECRecoverFunctionVerifierBuilder::dyn_verifier_builder()
         }
         i if i == BaseLayerCircuitType::RamValidation as u8 => {
-            RAMPermutationVerifierBuilder::<F, R>::dyn_verifier_builder()
+            RAMPermutationVerifierBuilder::dyn_verifier_builder()
         }
         i if i == BaseLayerCircuitType::StorageFilter as u8 => {
-            StorageSorterVerifierBuilder::<F, R>::dyn_verifier_builder()
+            StorageSorterVerifierBuilder::dyn_verifier_builder()
         }
         i if i == BaseLayerCircuitType::StorageApplicator as u8 => {
-            StorageApplicationVerifierBuilder::<F, R>::dyn_verifier_builder()
+            StorageApplicationVerifierBuilder::dyn_verifier_builder()
         }
         i if i == BaseLayerCircuitType::EventsRevertsFilter as u8 => {
-            EventsSorterVerifierBuilder::<F, R>::dyn_verifier_builder()
+            EventsSorterVerifierBuilder::dyn_verifier_builder()
         }
         i if i == BaseLayerCircuitType::L1MessagesRevertsFilter as u8 => {
-            L1MessagesSorterVerifierBuilder::<F, R>::dyn_verifier_builder()
+            L1MessagesSorterVerifierBuilder::dyn_verifier_builder()
         }
         i if i == BaseLayerCircuitType::L1MessagesHasher as u8 => {
-            L1MessagesHaherVerifierBuilder::<F, R>::dyn_verifier_builder()
+            L1MessagesHaherVerifierBuilder::dyn_verifier_builder()
         }
         _ => {
             panic!("unknown circuit type = {}", circuit_type);
@@ -105,13 +101,7 @@ where
 }
 
 pub fn dyn_recursive_verifier_builder_for_circuit_type<
-    F: SmallField,
-    EXT: FieldExtension<2, BaseField = F>,
-    CS: ConstraintSystem<F> + 'static,
-    R: BuildableCircuitRoundFunction<F, 8, 12, 4>
-        + AlgebraicRoundFunction<F, 8, 12, 4>
-        + serde::Serialize
-        + serde::de::DeserializeOwned,
+    CS: ConstraintSystem<GoldilocksField> + 'static,
 >(
     circuit_type: u8,
 ) -> Box<dyn crate::boojum::cs::traits::circuit::ErasedBuilderForRecursiveVerifier<F, EXT, CS>>
@@ -128,44 +118,43 @@ where
 
     match circuit_type {
         i if i == BaseLayerCircuitType::VM as u8 => {
-            VMMainCircuitVerifierBuilder::<F, VmWitnessOracle<F>, R>::dyn_recursive_verifier_builder(
-            )
+            VMMainCircuitVerifierBuilder::dyn_recursive_verifier_builder()
         }
         i if i == BaseLayerCircuitType::DecommitmentsFilter as u8 => {
-            CodeDecommittsSorterVerifierBuilder::<F, R>::dyn_recursive_verifier_builder()
+            CodeDecommittsSorterVerifierBuilder::dyn_recursive_verifier_builder()
         }
         i if i == BaseLayerCircuitType::Decommiter as u8 => {
-            CodeDecommitterVerifierBuilder::<F, R>::dyn_recursive_verifier_builder()
+            CodeDecommitterVerifierBuilder::dyn_recursive_verifier_builder()
         }
         i if i == BaseLayerCircuitType::LogDemultiplexer as u8 => {
-            LogDemuxerVerifierBuilder::<F, R>::dyn_recursive_verifier_builder()
+            LogDemuxerVerifierBuilder::dyn_recursive_verifier_builder()
         }
         i if i == BaseLayerCircuitType::KeccakPrecompile as u8 => {
-            Keccak256RoundFunctionVerifierBuilder::<F, R>::dyn_recursive_verifier_builder()
+            Keccak256RoundFunctionVerifierBuilder::dyn_recursive_verifier_builder()
         }
         i if i == BaseLayerCircuitType::Sha256Precompile as u8 => {
-            Sha256RoundFunctionVerifierBuilder::<F, R>::dyn_recursive_verifier_builder()
+            Sha256RoundFunctionVerifierBuilder::dyn_recursive_verifier_builder()
         }
         i if i == BaseLayerCircuitType::EcrecoverPrecompile as u8 => {
-            ECRecoverFunctionVerifierBuilder::<F, R>::dyn_recursive_verifier_builder()
+            ECRecoverFunctionVerifierBuilder::dyn_recursive_verifier_builder()
         }
         i if i == BaseLayerCircuitType::RamValidation as u8 => {
-            RAMPermutationVerifierBuilder::<F, R>::dyn_recursive_verifier_builder()
+            RAMPermutationVerifierBuilder::dyn_recursive_verifier_builder()
         }
         i if i == BaseLayerCircuitType::StorageFilter as u8 => {
-            StorageSorterVerifierBuilder::<F, R>::dyn_recursive_verifier_builder()
+            StorageSorterVerifierBuilder::dyn_recursive_verifier_builder()
         }
         i if i == BaseLayerCircuitType::StorageApplicator as u8 => {
-            StorageApplicationVerifierBuilder::<F, R>::dyn_recursive_verifier_builder()
+            StorageApplicationVerifierBuilder::dyn_recursive_verifier_builder()
         }
         i if i == BaseLayerCircuitType::EventsRevertsFilter as u8 => {
-            EventsSorterVerifierBuilder::<F, R>::dyn_recursive_verifier_builder()
+            EventsSorterVerifierBuilder::dyn_recursive_verifier_builder()
         }
         i if i == BaseLayerCircuitType::L1MessagesRevertsFilter as u8 => {
-            L1MessagesSorterVerifierBuilder::<F, R>::dyn_recursive_verifier_builder()
+            L1MessagesSorterVerifierBuilder::dyn_recursive_verifier_builder()
         }
         i if i == BaseLayerCircuitType::L1MessagesHasher as u8 => {
-            L1MessagesHaherVerifierBuilder::<F, R>::dyn_recursive_verifier_builder()
+            L1MessagesHaherVerifierBuilder::dyn_recursive_verifier_builder()
         }
         _ => {
             panic!("unknown circuit type = {}", circuit_type);

--- a/src/capacity_estimator.rs
+++ b/src/capacity_estimator.rs
@@ -137,88 +137,73 @@ where
 }
 
 pub fn main_vm_capacity() -> usize {
-    type SF = VmMainInstanceSynthesisFunction<
-        GoldilocksField,
-        VmWitnessOracle<GoldilocksField>,
-        ZkSyncDefaultRoundFunction,
-    >;
+    type SF = VmMainInstanceSynthesisFunction;
 
     compute_size_inner::<SF, _>(SF::geometry(), 20, Some(5500), |x: usize| x)
 }
 
 pub fn code_decommittments_sorter_capacity() -> usize {
-    type SF =
-        CodeDecommittmentsSorterSynthesisFunction<GoldilocksField, ZkSyncDefaultRoundFunction>;
+    type SF = CodeDecommittmentsSorterSynthesisFunction;
 
     compute_size_inner::<SF, _>(SF::geometry(), 20, Some(40000), |x: usize| x)
 }
 
 pub fn code_decommitter_capacity() -> usize {
-    type SF = CodeDecommitterInstanceSynthesisFunction<GoldilocksField, ZkSyncDefaultRoundFunction>;
+    type SF = CodeDecommitterInstanceSynthesisFunction;
 
     compute_size_inner::<SF, _>(SF::geometry(), 20, Some(2048), |x: usize| x)
 }
 
 pub fn log_demuxer_capacity() -> usize {
-    type SF = LogDemuxInstanceSynthesisFunction<GoldilocksField, ZkSyncDefaultRoundFunction>;
+    type SF = LogDemuxInstanceSynthesisFunction;
 
     compute_size_inner::<SF, _>(SF::geometry(), 20, Some(20000), |x: usize| x)
 }
 
 pub fn keccak256_rf_capacity() -> usize {
-    type SF = Keccak256RoundFunctionInstanceSynthesisFunction<
-        GoldilocksField,
-        ZkSyncDefaultRoundFunction,
-    >;
+    type SF = Keccak256RoundFunctionInstanceSynthesisFunction;
 
     compute_size_inner::<SF, _>(SF::geometry(), 20, Some(100), |x: usize| x)
 }
 
 pub fn sha256_rf_capacity() -> usize {
-    type SF =
-        Sha256RoundFunctionInstanceSynthesisFunction<GoldilocksField, ZkSyncDefaultRoundFunction>;
+    type SF = Sha256RoundFunctionInstanceSynthesisFunction;
 
     compute_size_inner::<SF, _>(SF::geometry(), 20, Some(2048), |x: usize| x)
 }
 
 pub fn ecrecover_capacity() -> usize {
-    type SF =
-        ECRecoverFunctionInstanceSynthesisFunction<GoldilocksField, ZkSyncDefaultRoundFunction>;
+    type SF = ECRecoverFunctionInstanceSynthesisFunction;
 
     compute_size_inner::<SF, _>(SF::geometry(), 20, Some(2), |x: usize| x)
 }
 
 pub fn ram_permutation_capacity() -> usize {
-    type SF = RAMPermutationInstanceSynthesisFunction<GoldilocksField, ZkSyncDefaultRoundFunction>;
+    type SF = RAMPermutationInstanceSynthesisFunction;
 
     compute_size_inner::<SF, _>(SF::geometry(), 20, Some(70000), |x: usize| x)
 }
 
 pub fn event_sorter_capacity() -> usize {
-    type SF = EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction<
-        GoldilocksField,
-        ZkSyncDefaultRoundFunction,
-    >;
+    type SF = EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction;
 
     compute_size_inner::<SF, _>(SF::geometry(), 20, Some(20000), |x: usize| x)
 }
 
 pub fn storage_sorter_capacity() -> usize {
-    type SF =
-        StorageSortAndDedupInstanceSynthesisFunction<GoldilocksField, ZkSyncDefaultRoundFunction>;
+    type SF = StorageSortAndDedupInstanceSynthesisFunction;
 
     compute_size_inner::<SF, _>(SF::geometry(), 20, Some(22000), |x: usize| x)
 }
 
 pub fn storage_application_capacity() -> usize {
-    type SF =
-        StorageApplicationInstanceSynthesisFunction<GoldilocksField, ZkSyncDefaultRoundFunction>;
+    type SF = StorageApplicationInstanceSynthesisFunction;
 
     compute_size_inner::<SF, _>(SF::geometry(), 20, Some(32), |x: usize| x)
 }
 
 pub fn l1_messages_hasher_capacity() -> usize {
-    type SF = LinearHasherInstanceSynthesisFunction<GoldilocksField, ZkSyncDefaultRoundFunction>;
+    type SF = LinearHasherInstanceSynthesisFunction;
 
     compute_size_inner::<SF, _>(SF::geometry(), 20, Some(512), |x: usize| x)
 }

--- a/src/compute_setups.rs
+++ b/src/compute_setups.rs
@@ -62,11 +62,7 @@ use crate::prover_utils::*;
 
 /// Returns all types of basic circuits, with empty witnesses.
 /// Can be used for things like verification key generation.
-fn get_all_basic_circuits(
-    geometry: &GeometryConfig,
-) -> Vec<
-    ZkSyncBaseLayerCircuit<GoldilocksField, VmWitnessOracle<GoldilocksField>, Poseidon2Goldilocks>,
-> {
+fn get_all_basic_circuits(geometry: &GeometryConfig) -> Vec<ZkSyncBaseLayerCircuit> {
     vec![
         ZkSyncBaseLayerCircuit::MainVM(ZkSyncUniformCircuitInstance {
             witness: AtomicCell::new(None),

--- a/src/external_calls.rs
+++ b/src/external_calls.rs
@@ -30,7 +30,6 @@ use crate::{
     ethereum_types::{Address, U256},
     utils::{calldata_to_aligned_data, u64_as_u32_le},
 };
-use ::tracing;
 use circuit_definitions::boojum::field::Field;
 use circuit_definitions::boojum::implementations::poseidon2::Poseidon2Goldilocks;
 use circuit_definitions::circuit_definitions::base_layer::ZkSyncBaseLayerCircuit;
@@ -39,6 +38,7 @@ use circuit_definitions::zkevm_circuits::fsm_input_output::ClosedFormInputCompac
 use circuit_definitions::{Field as MainField, RoundFunction, ZkSyncDefaultRoundFunction};
 use snark_wrapper::boojum::field::goldilocks::GoldilocksExt2;
 use snark_wrapper::boojum::gadgets::recursion::recursive_tree_hasher::CircuitGoldilocksPoseidon2Sponge;
+use tracing;
 
 pub const SCHEDULER_TIMESTAMP: u32 = 1;
 
@@ -60,7 +60,7 @@ use circuit_definitions::aux_definitions::witness_oracle::VmWitnessOracle;
 /// This function will setup the environment and will run out-of-circuit and then in-circuit
 pub fn run<
     S: Storage,
-    CB: FnMut(ZkSyncBaseLayerCircuit<MainField, VmWitnessOracle<MainField>, RoundFunction>),
+    CB: FnMut(ZkSyncBaseLayerCircuit),
     QSCB: FnMut(
         u64,
         RecursionQueueSimulator<MainField>,

--- a/src/prover_utils.rs
+++ b/src/prover_utils.rs
@@ -46,11 +46,7 @@ type RH = CircuitGoldilocksPoseidon2Sponge;
 use crate::boojum::cs::implementations::setup::FinalizationHintsForProver;
 
 pub fn create_base_layer_setup_data(
-    circuit: ZkSyncBaseLayerCircuit<
-        GoldilocksField,
-        VmWitnessOracle<GoldilocksField>,
-        ZkSyncDefaultRoundFunction,
-    >,
+    circuit: ZkSyncBaseLayerCircuit,
     worker: &Worker,
     fri_lde_factor: usize,
     merkle_tree_cap_size: usize,
@@ -207,11 +203,7 @@ use crate::boojum::cs::implementations::transcript::GoldilocksPoisedon2Transcrip
 use crate::boojum::cs::implementations::pow::PoWRunner;
 
 pub fn prove_base_layer_circuit<POW: PoWRunner>(
-    circuit: ZkSyncBaseLayerCircuit<
-        GoldilocksField,
-        VmWitnessOracle<GoldilocksField>,
-        ZkSyncDefaultRoundFunction,
-    >,
+    circuit: ZkSyncBaseLayerCircuit,
     worker: &Worker,
     proof_config: ProofConfig,
     setup_base: &SetupBaseStorage<F, P>,
@@ -357,20 +349,13 @@ pub fn prove_base_layer_circuit<POW: PoWRunner>(
 }
 
 pub fn verify_base_layer_proof<POW: PoWRunner>(
-    circuit: &ZkSyncBaseLayerCircuit<
-        GoldilocksField,
-        VmWitnessOracle<GoldilocksField>,
-        ZkSyncDefaultRoundFunction,
-    >,
+    circuit: &ZkSyncBaseLayerCircuit,
     proof: &Proof<F, H, EXT>,
     vk: &VerificationKey<F, H>,
 ) -> bool {
     use circuit_definitions::circuit_definitions::verifier_builder::dyn_verifier_builder_for_circuit_type;
 
-    let verifier_builder =
-        dyn_verifier_builder_for_circuit_type::<F, EXT, ZkSyncDefaultRoundFunction>(
-            circuit.numeric_circuit_type(),
-        );
+    let verifier_builder = dyn_verifier_builder_for_circuit_type(circuit.numeric_circuit_type());
     let verifier = verifier_builder.create_verifier();
     // let verifier = verifier_builder.create_dyn_verifier();
     verifier.verify::<H, TR, POW>((), vk, proof)
@@ -381,8 +366,7 @@ pub fn verify_base_layer_proof_for_type<POW: PoWRunner>(
     proof: &Proof<F, H, EXT>,
     vk: &VerificationKey<F, H>,
 ) -> bool {
-    let verifier_builder =
-        dyn_verifier_builder_for_circuit_type::<F, EXT, ZkSyncDefaultRoundFunction>(circuit_type);
+    let verifier_builder = dyn_verifier_builder_for_circuit_type(circuit_type);
     let verifier = verifier_builder.create_verifier();
     verifier.verify::<H, TR, POW>((), vk, proof)
 }
@@ -726,7 +710,7 @@ pub fn verify_compression_layer_proof<POW: PoWRunner>(
 }
 
 pub fn create_eip4844_setup_data(
-    circuit: EIP4844Circuit<GoldilocksField, ZkSyncDefaultRoundFunction>,
+    circuit: EIP4844Circuit,
     worker: &Worker,
     fri_lde_factor: usize,
     merkle_tree_cap_size: usize,
@@ -777,7 +761,7 @@ pub fn create_eip4844_setup_data(
 }
 
 pub fn prove_eip4844_circuit<POW: PoWRunner>(
-    circuit: EIP4844Circuit<GoldilocksField, ZkSyncDefaultRoundFunction>,
+    circuit: EIP4844Circuit,
     worker: &Worker,
     proof_config: ProofConfig,
     setup_base: &SetupBaseStorage<F, P>,
@@ -824,12 +808,10 @@ pub fn prove_eip4844_circuit<POW: PoWRunner>(
 }
 
 pub fn verify_eip4844_proof<POW: PoWRunner>(
-    circuit: &EIP4844Circuit<GoldilocksField, ZkSyncDefaultRoundFunction>,
     proof: &Proof<F, H, EXT>,
     vk: &VerificationKey<F, H>,
 ) -> bool {
-    let verifier_builder =
-        EIP4844VerifierBuilder::<F, ZkSyncDefaultRoundFunction>::dyn_verifier_builder();
+    let verifier_builder = EIP4844VerifierBuilder::dyn_verifier_builder();
     let verifier = verifier_builder.create_verifier();
     // let verifier = verifier_builder.create_dyn_verifier();
     verifier.verify::<H, TR, POW>((), vk, proof)

--- a/src/tests/complex_tests/invididual_debugs.rs
+++ b/src/tests/complex_tests/invididual_debugs.rs
@@ -8,21 +8,11 @@ mod test {
     use circuit_definitions::encodings::recursion_request::RecursionQueueSimulator;
     use std::io::Read;
 
-    type BaseLayerCircuit = ZkSyncBaseLayerCircuit<
-        GoldilocksField,
-        VmWitnessOracle<GoldilocksField>,
-        ZkSyncDefaultRoundFunction,
-    >;
+    type BaseLayerCircuit = ZkSyncBaseLayerCircuit;
 
     #[derive(serde::Serialize, serde::Deserialize)]
     pub enum CircuitWrapper {
-        Base(
-            ZkSyncBaseLayerCircuit<
-                GoldilocksField,
-                VmWitnessOracle<GoldilocksField>,
-                ZkSyncDefaultRoundFunction,
-            >,
-        ),
+        Base(ZkSyncBaseLayerCircuit),
         Recursive(ZkSyncRecursiveLayerCircuit),
     }
 

--- a/src/tests/complex_tests/mod.rs
+++ b/src/tests/complex_tests/mod.rs
@@ -141,7 +141,7 @@ pub(crate) fn generate_base_layer(
     cycle_limit: usize,
     geometry: GeometryConfig,
 ) -> (
-    Vec<ZkSyncBaseLayerCircuit<Field, VmWitnessOracle<Field>, RoundFunction>>,
+    Vec<ZkSyncBaseLayerCircuit>,
     Vec<(
         u64,
         RecursionQueueSimulator<Field>,
@@ -1067,7 +1067,7 @@ fn run_and_try_create_witness_inner(
                 &finalization_hint,
             );
 
-            let is_valid = verify_eip4844_proof::<NoPow>(&circuit, &proof, &vk);
+            let is_valid = verify_eip4844_proof::<NoPow>(&proof, &vk);
             assert!(is_valid);
 
             eip4844_proofs.push(proof);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -97,9 +97,7 @@ pub(crate) fn save_predeployed_contracts(
 
 // NOTE: this is here while the EIP circuit isn't considered base layer, and should be removed once
 // it is made a base layer circuit in a later version.
-pub(crate) fn eip4844_test_circuit(
-    circuit: EIP4844Circuit<GoldilocksField, ZkSyncDefaultRoundFunction>,
-) {
+pub(crate) fn eip4844_test_circuit(circuit: EIP4844Circuit) {
     use crate::boojum::config::DevCSConfig;
     use crate::boojum::cs::cs_builder::new_builder;
     use crate::boojum::cs::cs_builder_reference::CsReferenceImplementationBuilder;
@@ -129,13 +127,7 @@ pub(crate) fn eip4844_test_circuit(
     assert!(is_satisfied);
 }
 
-pub(crate) fn base_test_circuit(
-    circuit: ZkSyncBaseLayerCircuit<
-        GoldilocksField,
-        VmWitnessOracle<GoldilocksField>,
-        ZkSyncDefaultRoundFunction,
-    >,
-) {
+pub(crate) fn base_test_circuit(circuit: ZkSyncBaseLayerCircuit) {
     use crate::boojum::config::DevCSConfig;
     use crate::boojum::cs::cs_builder::new_builder;
     use crate::boojum::cs::cs_builder_reference::CsReferenceImplementationBuilder;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -208,14 +208,12 @@ pub fn generate_eip4844_witness<F: SmallField>(
     // compute versioned hash
 
     // There chunks are representation of the monomial form
-    let mut poly = crate::zkevm_circuits::eip_4844::zksync_pubdata_into_monomial_form_poly(
-        &blob
-    );
+    let mut poly = crate::zkevm_circuits::eip_4844::zksync_pubdata_into_monomial_form_poly(&blob);
     // so FFT then
     crate::zkevm_circuits::eip_4844::fft(&mut poly);
     // and bitreverse
     crate::zkevm_circuits::eip_4844::bitreverse(&mut poly);
-    // now they can be an input to KZG commitment 
+    // now they can be an input to KZG commitment
 
     use crate::kzg::compute_commitment;
     use circuit_definitions::boojum::pairing::CurveAffine;
@@ -300,7 +298,7 @@ pub fn generate_eip4844_circuit_and_witness(
     blob: Vec<u8>,
     trusted_setup_path: &str,
 ) -> (
-    EIP4844Circuit<GoldilocksField, ZkSyncDefaultRoundFunction>,
+    EIP4844Circuit,
     EIP4844CircuitInstanceWitness<GoldilocksField>,
 ) {
     let (blob_arr, linear_hash, versioned_hash, output_hash) =

--- a/src/witness/individual_circuits/log_demux.rs
+++ b/src/witness/individual_circuits/log_demux.rs
@@ -18,7 +18,7 @@ use circuit_definitions::{encodings::*, Field, RoundFunction};
 
 /// Take a storage log, output logs separately for events, l1 messages, storage, etc
 pub fn compute_logs_demux<
-    CB: FnMut(ZkSyncBaseLayerCircuit<Field, VmWitnessOracle<Field>, Poseidon2Goldilocks>),
+    CB: FnMut(ZkSyncBaseLayerCircuit),
     QSCB: FnMut(u64, RecursionQueueSimulator<Field>, Vec<ClosedFormInputCompactFormWitness<Field>>),
 >(
     artifacts: &mut FullBlockArtifacts<Field>,
@@ -30,7 +30,7 @@ pub fn compute_logs_demux<
     mut circuit_callback: CB,
     mut recursion_queue_callback: QSCB,
 ) -> (
-    FirstAndLastCircuit<LogDemuxInstanceSynthesisFunction<GoldilocksField, Poseidon2Goldilocks>>,
+    FirstAndLastCircuit<LogDemuxInstanceSynthesisFunction>,
     Vec<ClosedFormInputCompactFormWitness<GoldilocksField>>,
     LogQueue<Field>,
     LogQueue<Field>,

--- a/src/witness/individual_circuits/ram_permutation.rs
+++ b/src/witness/individual_circuits/ram_permutation.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use crate::zk_evm::zkevm_opcode_defs::BOOTLOADER_HEAP_PAGE;
 
 pub fn compute_ram_circuit_snapshots<
-    CB: FnMut(ZkSyncBaseLayerCircuit<Field, VmWitnessOracle<Field>, Poseidon2Goldilocks>),
+    CB: FnMut(ZkSyncBaseLayerCircuit),
     QSCB: FnMut(u64, RecursionQueueSimulator<Field>, Vec<ClosedFormInputCompactFormWitness<Field>>),
 >(
     artifacts: &mut FullBlockArtifacts<Field>,
@@ -37,7 +37,7 @@ pub fn compute_ram_circuit_snapshots<
     mut circuit_callback: CB,
     mut recursion_queue_callback: QSCB,
 ) -> (
-    FirstAndLastCircuit<RAMPermutationInstanceSynthesisFunction<Field, RoundFunction>>,
+    FirstAndLastCircuit<RAMPermutationInstanceSynthesisFunction>,
     Vec<ClosedFormInputCompactFormWitness<Field>>,
 ) {
     assert!(

--- a/src/witness/individual_circuits/storage_application.rs
+++ b/src/witness/individual_circuits/storage_application.rs
@@ -29,13 +29,7 @@ use tracing;
 use crate::sha3::Digest;
 
 pub fn decompose_into_storage_application_witnesses<
-    CB: FnMut(
-        ZkSyncBaseLayerCircuit<
-            GoldilocksField,
-            VmWitnessOracle<GoldilocksField>,
-            Poseidon2Goldilocks,
-        >,
-    ),
+    CB: FnMut(ZkSyncBaseLayerCircuit),
     QSCB: FnMut(
         u64,
         RecursionQueueSimulator<GoldilocksField>,
@@ -52,9 +46,7 @@ pub fn decompose_into_storage_application_witnesses<
     mut circuit_callback: CB,
     mut recursion_queue_callback: QSCB,
 ) -> (
-    FirstAndLastCircuit<
-        StorageApplicationInstanceSynthesisFunction<GoldilocksField, Poseidon2Goldilocks>,
-    >,
+    FirstAndLastCircuit<StorageApplicationInstanceSynthesisFunction>,
     Vec<ClosedFormInputCompactFormWitness<GoldilocksField>>,
 ) {
     use crate::witness::tree::EnumeratedBinaryLeaf;

--- a/src/witness/oracle.rs
+++ b/src/witness/oracle.rs
@@ -183,13 +183,7 @@ use crate::blake2::Blake2s256;
 use crate::witness::tree::*;
 
 pub fn create_artifacts_from_tracer<
-    CB: FnMut(
-        ZkSyncBaseLayerCircuit<
-            GoldilocksField,
-            VmWitnessOracle<GoldilocksField>,
-            Poseidon2Goldilocks,
-        >,
-    ),
+    CB: FnMut(ZkSyncBaseLayerCircuit),
     QSCB: FnMut(
         u64,
         RecursionQueueSimulator<GoldilocksField>,

--- a/src/witness/postprocessing/mod.rs
+++ b/src/witness/postprocessing/mod.rs
@@ -92,35 +92,26 @@ use crate::boojum::gadgets::traits::allocatable::CSAllocatableExt;
 use crate::boojum::gadgets::traits::round_function::*;
 
 pub struct BlockFirstAndLastBasicCircuits {
-    pub main_vm_circuits: FirstAndLastCircuit<
-        VmMainInstanceSynthesisFunction<Field, VmWitnessOracle<Field>, RoundFunction>,
-    >,
+    pub main_vm_circuits: FirstAndLastCircuit<VmMainInstanceSynthesisFunction>,
     pub code_decommittments_sorter_circuits:
-        FirstAndLastCircuit<CodeDecommittmentsSorterSynthesisFunction<Field, RoundFunction>>,
-    pub code_decommitter_circuits:
-        FirstAndLastCircuit<CodeDecommitterInstanceSynthesisFunction<Field, RoundFunction>>,
-    pub log_demux_circuits:
-        FirstAndLastCircuit<LogDemuxInstanceSynthesisFunction<Field, RoundFunction>>,
+        FirstAndLastCircuit<CodeDecommittmentsSorterSynthesisFunction>,
+    pub code_decommitter_circuits: FirstAndLastCircuit<CodeDecommitterInstanceSynthesisFunction>,
+    pub log_demux_circuits: FirstAndLastCircuit<LogDemuxInstanceSynthesisFunction>,
     pub keccak_precompile_circuits:
-        FirstAndLastCircuit<Keccak256RoundFunctionInstanceSynthesisFunction<Field, RoundFunction>>,
+        FirstAndLastCircuit<Keccak256RoundFunctionInstanceSynthesisFunction>,
     pub sha256_precompile_circuits:
-        FirstAndLastCircuit<Sha256RoundFunctionInstanceSynthesisFunction<Field, RoundFunction>>,
+        FirstAndLastCircuit<Sha256RoundFunctionInstanceSynthesisFunction>,
     pub ecrecover_precompile_circuits:
-        FirstAndLastCircuit<ECRecoverFunctionInstanceSynthesisFunction<Field, RoundFunction>>,
-    pub ram_permutation_circuits:
-        FirstAndLastCircuit<RAMPermutationInstanceSynthesisFunction<Field, RoundFunction>>,
-    pub storage_sorter_circuits:
-        FirstAndLastCircuit<StorageSortAndDedupInstanceSynthesisFunction<Field, RoundFunction>>,
+        FirstAndLastCircuit<ECRecoverFunctionInstanceSynthesisFunction>,
+    pub ram_permutation_circuits: FirstAndLastCircuit<RAMPermutationInstanceSynthesisFunction>,
+    pub storage_sorter_circuits: FirstAndLastCircuit<StorageSortAndDedupInstanceSynthesisFunction>,
     pub storage_application_circuits:
-        FirstAndLastCircuit<StorageApplicationInstanceSynthesisFunction<Field, RoundFunction>>,
-    pub events_sorter_circuits: FirstAndLastCircuit<
-        EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction<Field, RoundFunction>,
-    >,
-    pub l1_messages_sorter_circuits: FirstAndLastCircuit<
-        EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction<Field, RoundFunction>,
-    >,
-    pub l1_messages_hasher_circuits:
-        FirstAndLastCircuit<LinearHasherInstanceSynthesisFunction<Field, RoundFunction>>,
+        FirstAndLastCircuit<StorageApplicationInstanceSynthesisFunction>,
+    pub events_sorter_circuits:
+        FirstAndLastCircuit<EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction>,
+    pub l1_messages_sorter_circuits:
+        FirstAndLastCircuit<EventsAndL1MessagesSortAndDedupInstanceSynthesisFunction>,
+    pub l1_messages_hasher_circuits: FirstAndLastCircuit<LinearHasherInstanceSynthesisFunction>,
 }
 
 pub struct FirstAndLastCircuit<S>


### PR DESCRIPTION
Improving compilation speed by avoiding generics - moving to branch 1.5.0