### PR TITLE
Accept trusted setup as argument

### DIFF
--- a/src/external_calls.rs
+++ b/src/external_calls.rs
@@ -72,6 +72,7 @@ pub fn run<
     geometry: GeometryConfig,
     storage: S,
     tree: &mut impl BinarySparseStorageTree<256, 32, 32, 8, 32, Blake2s256, ZkSyncStorageLeaf>,
+    trusted_setup_path: &str,
     eip_4844_repack_inputs: [Option<Vec<u8>>; MAX_4844_BLOBS_PER_BLOCK],
     circuit_callback: CB,
     queue_simulator_callback: QSCB,
@@ -240,6 +241,7 @@ pub fn run<
         default_aa_code_hash,
         evm_simulator_code_hash,
         eip_4844_repack_inputs.clone(),
+        trusted_setup_path,
         circuit_callback,
         queue_simulator_callback,
     );

--- a/src/tests/complex_tests/mod.rs
+++ b/src/tests/complex_tests/mod.rs
@@ -266,6 +266,7 @@ pub(crate) fn generate_base_layer(
         geometry,
         storage_impl,
         &mut tree,
+        "kzg/src/trusted_setup.json",
         blobs,
         |circuit| basic_block_circuits.push(circuit),
         |a, b, c| {

--- a/src/tests/run_manually.rs
+++ b/src/tests/run_manually.rs
@@ -235,6 +235,7 @@ pub(crate) fn run_and_try_create_witness_for_extended_state(
         geometry,
         storage_impl,
         &mut tree,
+        "kzg/src/trusted_setup.json",
         std::array::from_fn(|_| None),
         |circuit| basic_block_circuits.push(circuit),
         |_, _, _| {},

--- a/src/witness/oracle.rs
+++ b/src/witness/oracle.rs
@@ -195,6 +195,7 @@ pub fn create_artifacts_from_tracer<
     default_aa_code_hash: U256,
     evm_simulator_code_hash: U256,
     eip_4844_repack_inputs: [Option<Vec<u8>>; MAX_4844_BLOBS_PER_BLOCK],
+    trusted_setup_path: &str,
     mut circuit_callback: CB,
     mut recursion_queue_callback: QSCB,
 ) -> (
@@ -1873,10 +1874,7 @@ pub fn create_artifacts_from_tracer<
             };
             use crate::generate_eip4844_witness;
             let (chunks, linear_hash, versioned_hash, output_hash) =
-                generate_eip4844_witness::<GoldilocksField>(
-                    &input_witness[..],
-                    "kzg/src/trusted_setup.json",
-                );
+                generate_eip4844_witness::<GoldilocksField>(&input_witness[..], trusted_setup_path);
             let data_chunks: VecDeque<_> = chunks
                 .iter()
                 .map(|el| BlobChunkWitness { inner: *el })


### PR DESCRIPTION
# What ❔

* Accept trusted setup path as argument - used for 4844 blobs

## Why ❔

* This allows the callers to provide their own path, rather than depending on the hardcoded one.
